### PR TITLE
Catch up with changes to env_logger in rust-lang-nursery/log

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -215,7 +215,7 @@ impl Builder {
             filter: None,
             format: Box::new(|record: &Record| {
                 format!("{}:{}: {}", record.level(),
-                        record.location().module_path(), record.args())
+                        record.module_path(), record.args())
             }),
             target: Target::Stderr,
         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -375,6 +375,8 @@ impl Log for Logger {
             },
         };
     }
+
+    fn flush(&self) {}
 }
 
 struct Directive {


### PR DESCRIPTION
There were a few small changes to `env_logger` in rust-lang-nursery/log:

- rust-lang-nursery/log#196
- rust-lang-nursery/log#200

Without these changes, this crate does not compile.