### PR TITLE
A few improvements to the documentation

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -195,8 +195,8 @@ pub struct Logger {
 ///     let mut builder = Builder::new();
 ///     builder.format(format).filter(None, LevelFilter::Info);
 ///
-///     if env::var("RUST_LOG").is_ok() {
-///        builder.parse(&env::var("RUST_LOG").unwrap());
+///     if let Ok(rust_log) = env::var("RUST_LOG") {
+///        builder.parse(&rust_log);
 ///     }
 ///
 ///     builder.init();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -171,7 +171,8 @@ pub struct Logger {
     target: Target,
 }
 
-/// Builder acts as builder for initializing the Logger.
+/// `Builder` acts as builder for initializing a `Logger`.
+///
 /// It can be used to customize the log format, change the enviromental variable used
 /// to provide the logging directives and also set the default log level filter.
 ///
@@ -273,11 +274,15 @@ impl Builder {
         self
     }
 
-    /// Initializes the global logger with an env logger.
+    /// Initializes the global logger with the built env logger.
     ///
-    /// This should be called early in the execution of a Rust program, and the
-    /// global logger may only be initialized once. Future initialization
-    /// attempts will return error.
+    /// This should be called early in the execution of a Rust program. Any log
+    /// events that occur before initialization will be ignored.
+    ///
+    /// # Errors
+    ///
+    /// This function will fail if it is called more than once, or if another
+    /// library has already initialized a global logger.
     pub fn try_init(&mut self) -> Result<(), SetLoggerError> {
         log::try_set_logger(|max_level| {
             let logger = self.build();
@@ -286,11 +291,15 @@ impl Builder {
         })
     }
 
-    /// Initializes the global logger with an env logger.
+    /// Initializes the global logger with the built env logger.
     ///
-    /// This should be called early in the execution of a Rust program, and the
-    /// global logger may only be initialized once. Future initialization
-    /// attempts will panic.
+    /// This should be called early in the execution of a Rust program. Any log
+    /// events that occur before initialization will be ignored.
+    ///
+    /// # Panics
+    ///
+    /// This function will panic if it is called more than once, or if another
+    /// library has already initialized a global logger.
     pub fn init(&mut self) {
         let logger = self.build();
         let filter = logger.filter();
@@ -388,9 +397,13 @@ struct Directive {
 
 /// Initializes the global logger with an env logger.
 ///
-/// This should be called early in the execution of a Rust program, and the
-/// global logger may only be initialized once. Future initialization attempts
-/// will return an error.
+/// This should be called early in the execution of a Rust program. Any log
+/// events that occur before initialization will be ignored.
+///
+/// # Errors
+///
+/// This function will fail if it is called more than once, or if another
+/// library has already initialized a global logger.
 pub fn try_init() -> Result<(), SetLoggerError> {
     let mut builder = Builder::new();
 
@@ -403,9 +416,13 @@ pub fn try_init() -> Result<(), SetLoggerError> {
 
 /// Initializes the global logger with an env logger.
 ///
-/// This should be called early in the execution of a Rust program, and the
-/// global logger may only be initialized once. Future initialization attempts
-/// will panic.
+/// This should be called early in the execution of a Rust program. Any log
+/// events that occur before initialization will be ignored.
+///
+/// # Panics
+///
+/// This function will panic if it is called more than once, or if another
+/// library has already initialized a global logger.
 pub fn init() {
     let mut builder = Builder::new();
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -109,7 +109,7 @@
 //!
 //! ## Filtering results
 //!
-//! A RUST_LOG directive may include a regex filter. The syntax is to append `/`
+//! A `RUST_LOG` directive may include a regex filter. The syntax is to append `/`
 //! followed by a regex. Each message is checked against the regex, and is only
 //! logged if it matches. Note that the matching is done after formatting the
 //! log string but before adding any logging meta-data. There is a single filter
@@ -258,7 +258,7 @@ impl Builder {
         self
     }
 
-    /// Parses the directives string in the same form as the RUST_LOG
+    /// Parses the directives string in the same form as the `RUST_LOG`
     /// environment variable.
     ///
     /// See the module documentation for more details.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,7 +9,8 @@
 // except according to those terms.
 
 //! A logger configured via an environment variable which writes to standard
-//! error.
+//! error, for use with the logging facade exposed by the
+//! [`log` crate][log-crate-url].
 //!
 //! ## Example
 //!
@@ -69,7 +70,8 @@
 //! INFO:main: the answer was: 12
 //! ```
 //!
-//! See the documentation for the log crate for more information about its API.
+//! See the documentation for the [`log` crate][log-crate-url] for more
+//! information about its API.
 //!
 //! ## Enabling logging
 //!
@@ -124,6 +126,8 @@
 //! * `error,hello=warn/[0-9] scopes` turn on global error logging and also
 //!   warn for hello. In both cases the log message must include a single digit
 //!   number followed by 'scopes'.
+//!
+//! [log-crate-url]: https://docs.rs/log/
 
 #![doc(html_logo_url = "http://www.rust-lang.org/logos/rust-logo-128x128-blk-v2.png",
        html_favicon_url = "http://www.rust-lang.org/favicon.ico",


### PR DESCRIPTION
This PR makes a bunch of changes to the documentation in order to fix:

- #11: Make reference to log crate into a hyperlink. Add an extra line to the summary at the beginning of the module-level documentation to indicate that this crate should be used with the standard logging facade (unlike something like `slog`).
- Consistently use monospaced font for `RUST_LOG`.
- #10: Add Errors/Panics section to `init()`/`try_init()` docs.
- #9: Avoid `unwrap()` in `Builder` doc string.
- #8: Provide examples for `Logger::new()` and `Logger:filter()`. Expand doc string for `Logger` to give more context and links to the typical ways of constructing it.

Please let me know if you'd like these changes as separate PRs - they are already separated by commit.

This PR needs the changes from #15 before it will compile or pass tests. (I've merged the two branches locally and confirmed both `cargo check`/`cargo doc` and `cargo test` produce the correct output).

