### PR TITLE
Update Cargo.toml metadata.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,15 +3,15 @@ name = "env_logger"
 version = "0.4.3" # remember to update html_root_url
 authors = ["The Rust Project Developers"]
 license = "MIT/Apache-2.0"
-repository = "https://github.com/rust-lang/log"
+readme = "README.md"
+repository = "https://github.com/sebasmagri/env_logger/"
 documentation = "https://docs.rs/env_logger"
-homepage = "https://github.com/rust-lang/log"
 description = """
 A logging implementation for `log` which is configured via an environment
 variable.
 """
 categories = ["development-tools::debugging"]
-keywords = ["logging"]
+keywords = ["logging", "log", "logger"]
 publish = false # this branch contains breaking changes
 
 [dependencies]


### PR DESCRIPTION
 - Change repository URL to point to new home.
 - Remove homepage URL as it matches repository and [C-METADATA](https://rust-lang-nursery.github.io/api-guidelines/documentation.html#cargotoml-includes-all-common-metadata-c-metadata) says not to duplicate.
 - Add some more keywords.
 - Link to README.md, which will cause it to get displayed on crates.io too.

@sebasmagri - You might want to add yourself to the 'authors' section now that you are the maintainer. It didn't feel right for me to do it. :)

Fixes #12.