### PR TITLE
Update to the latest commit of `log` / deny debug impls, missing docs, and warnings.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ keywords = ["logging", "log", "logger"]
 publish = false # this branch contains breaking changes
 
 [dependencies]
-log = { git = "https://github.com/rust-lang-nursery/log.git" }
+log = { git = "https://github.com/rust-lang-nursery/log.git", features = ["use_std"] }
 regex = { version = "0.2", optional = true }
 
 [[test]]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -188,6 +188,8 @@
 #![cfg_attr(rustbuild, feature(staged_api, rustc_private))]
 #![cfg_attr(rustbuild, unstable(feature = "rustc_private", issue = "27812"))]
 
+#![deny(missing_debug_implementations, missing_docs, warnings)]
+
 extern crate log;
 
 use std::env;
@@ -209,8 +211,11 @@ mod filter;
 /// Log target, either stdout or stderr.
 #[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
 pub enum Target {
+    /// Logs will be sent to standard output.
     Stdout,
+    /// Logs will be sent to standard error.
     Stderr,
+    /// Logs will be silenced.
     Silent,
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -365,7 +365,7 @@ impl Builder {
     /// This function will fail if it is called more than once, or if another
     /// library has already initialized a global logger.
     pub fn try_init(&mut self) -> Result<(), SetLoggerError> {
-        log::try_set_logger(|max_level| {
+        log::set_boxed_logger(|max_level| {
             let logger = self.build();
             max_level.set(logger.filter());
             Box::new(logger)
@@ -382,10 +382,7 @@ impl Builder {
     /// This function will panic if it is called more than once, or if another
     /// library has already initialized a global logger.
     pub fn init(&mut self) {
-        let logger = self.build();
-        let filter = logger.filter();
-        let logger = Box::new(logger);
-        log::set_logger(logger, filter);
+        self.try_init().unwrap();
     }
 
     /// Build an env logger.
@@ -435,9 +432,11 @@ impl Logger {
     /// use env_logger::Logger;
     ///
     /// fn main() {
-    ///     let logger = Box::new(Logger::new());
-    ///     let filter = logger.filter();
-    ///     log::set_logger(logger, filter);
+    ///     log::set_boxed_logger(|max_level| {
+    ///         let logger = Logger::new();
+    ///         max_level.set(logger.filter());
+    ///         Box::new(logger)
+    ///     });
     /// }
     /// ```
     ///


### PR DESCRIPTION
I was adding a deny attribute for missing debug impls, missing docs, and warnings, and discovered the crate doesn't compile against the latest API changes to `log`'s master branch, so I updated that too.