### PR TITLE
Add examples for custom format and logger impls

### DIFF
--- a/examples/custom_format.rs
+++ b/examples/custom_format.rs
@@ -1,0 +1,33 @@
+/*!
+Changing the default logging format.
+
+Before running this example, try setting the `MY_LOG_LEVEL` environment variable to `info`:
+
+```no_run,shell
+$ export MY_LOG_LEVEL = 'info'
+```
+
+If you want to control the logging output completely, see the `custom_logger` example.
+*/
+
+#[macro_use]
+extern crate log;
+extern crate env_logger;
+
+use std::env;
+
+fn main() {
+    let mut builder = env_logger::Builder::new();
+
+    builder.format(|buf, record| {
+        writeln!(buf, "My formatted log: {}", record.args())
+    });
+
+    if let Ok(s) = env::var("MY_LOG_LEVEL") {
+        builder.parse(&s);
+    }
+
+    builder.init();
+
+    info!("a log from `MyLogger`");
+}

--- a/examples/custom_logger.rs
+++ b/examples/custom_logger.rs
@@ -1,0 +1,67 @@
+/*!
+Using `env_logger` to drive a custom logger.
+
+Before running this example, try setting the `MY_LOG_LEVEL` environment variable to `info`:
+
+```no_run,shell
+$ export MY_LOG_LEVEL = 'info'
+```
+
+If you only want to change the way logs are formatted, look at the `custom_format` example.
+*/
+
+#[macro_use]
+extern crate log;
+extern crate env_logger;
+use env_logger::Logger as EnvLogger;
+use log::{Log, Metadata, Record, SetLoggerError};
+
+struct MyLogger {
+    inner: EnvLogger
+}
+
+impl MyLogger {
+    fn new() -> MyLogger {
+        use env_logger::{Builder, Target};
+        let mut builder = Builder::new();
+        builder.target(Target::Silent);
+
+        if let Ok(ref filter) = std::env::var("MY_LOG_LEVEL") {
+           builder.parse(filter);
+        }
+
+        MyLogger {
+            inner: builder.build()
+        }
+    }
+
+    fn init() -> Result<(), SetLoggerError> {
+        log::set_boxed_logger(|max_level| {
+            let logger = Self::new();
+            max_level.set(logger.inner.filter());
+            Box::new(logger)
+        })
+    }
+}
+
+impl Log for MyLogger {
+    fn enabled(&self, metadata: &Metadata) -> bool {
+        self.inner.enabled(metadata)
+    }
+
+    fn log(&self, record: &Record) {
+        if self.inner.matches(record) {
+            println!("{} - {}", record.level(), record.args());
+        }
+    }
+
+    fn flush(&self) {
+        self.inner.flush()
+    }
+}
+
+fn main() {
+    MyLogger::init().unwrap();
+
+    info!("a log from `MyLogger`");
+}


### PR DESCRIPTION
I think it would be good for use to build up a set of complete cargo examples. Here I've added two:

- Creating a custom logger (maybe we should make this one write to an in-memory `Vec<String>` or something?)
- Setting a custom format

These seem like good ones to start with because they use some new APIs we've introduced. We can use them to drive any changes we want to make to those APIs to make them a bit more ergonomic.