### PR TITLE
Support colors and buffer writes

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ publish = false # this branch contains breaking changes
 [dependencies]
 log = { git = "https://github.com/rust-lang-nursery/log.git", features = ["std"] }
 regex = { version = "0.2", optional = true }
-termcolor = "*"
+termcolor = "0.3"
 
 [[test]]
 name = "regexp_filter"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,7 @@ publish = false # this branch contains breaking changes
 [dependencies]
 log = { git = "https://github.com/rust-lang-nursery/log.git", features = ["std"] }
 regex = { version = "0.2", optional = true }
+termcolor = "*"
 
 [[test]]
 name = "regexp_filter"

--- a/examples/custom_format.rs
+++ b/examples/custom_format.rs
@@ -15,6 +15,7 @@ extern crate log;
 extern crate env_logger;
 
 use std::env;
+use std::io::Write;
 
 fn init_logger() {
     let mut builder = env_logger::Builder::new();

--- a/examples/default.rs
+++ b/examples/default.rs
@@ -1,0 +1,23 @@
+/*!
+Using `env_logger`.
+
+Before running this example, try setting the `MY_LOG_LEVEL` environment variable to `info`:
+
+```no_run,shell
+$ export MY_LOG_LEVEL = 'info'
+```
+*/
+
+#[macro_use]
+extern crate log;
+extern crate env_logger;
+
+fn main() {
+    env_logger::init_from_env("MY_LOG_LEVEL");
+
+    trace!("some trace log");
+    debug!("some debug log");
+    info!("some information log");
+    warn!("some warning log");
+    error!("some error log");
+}

--- a/src/fmt.rs
+++ b/src/fmt.rs
@@ -1,0 +1,93 @@
+//! Formatting for log records.
+//! 
+//! This module contains a [`Formatter`] that can be used to format log records
+//! into without needing temporary allocations. Usually you won't need to worry
+//! about the contents of this module and can use the `Formatter` like an ordinary
+//! [`Write`].
+//! 
+//! [`Formatter`]: struct.Formatter.html
+//! [`Write`]: https://doc.rust-lang.org/stable/std/io/trait.Write.html
+
+use std::io::prelude::*;
+use std::io;
+use std::fmt;
+
+use termcolor::{Color, ColorSpec, Buffer, WriteColor};
+
+/// A formatter to write logs into.
+/// 
+/// `Formatter` implements the standard [`Write`] trait for writing log records.
+/// It also supports terminal colors, but this is currently private.
+/// 
+/// [`Write`]: https://doc.rust-lang.org/stable/std/io/trait.Write.html
+pub struct Formatter {
+    buf: Buffer,
+}
+
+/// A formatter with a particular style.
+/// 
+/// Each call to `write` will apply the style before writing the output.
+pub(crate) struct StyledFormatter<W> {
+    buf: W,
+    spec: ColorSpec,
+}
+
+impl Formatter {
+    pub(crate) fn new(buf: Buffer) -> Self {
+        Formatter {
+            buf: buf,
+        }
+    }
+
+    pub(crate) fn color(&mut self, color: Color) -> StyledFormatter<&mut Buffer> {
+        let mut spec = ColorSpec::new();
+        spec.set_fg(Some(color));
+
+        StyledFormatter {
+            buf: &mut self.buf,
+            spec: spec
+        }
+    }
+
+    pub(crate) fn as_ref(&self) -> &Buffer {
+        &self.buf
+    }
+
+    pub(crate) fn clear(&mut self) {
+        self.buf.clear()
+    }
+}
+
+impl Write for Formatter {
+    fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
+        self.buf.write(buf)
+    }
+
+    fn flush(&mut self) -> io::Result<()> {
+        self.buf.flush()
+    }
+}
+
+impl<W> Write for StyledFormatter<W>
+    where W: WriteColor
+{
+    fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
+        self.buf.set_color(&self.spec)?;
+
+        // Always try to reset the terminal style, even if writing failed
+        let write = self.buf.write(buf);
+        let reset = self.buf.reset();
+
+        write.and_then(|w| reset.map(|_| w))
+    }
+
+    fn flush(&mut self) -> io::Result<()> {
+        self.buf.flush()
+    }
+}
+
+impl fmt::Debug for Formatter{
+    fn fmt(&self, f: &mut fmt::Formatter)->fmt::Result {
+        f.debug_struct("Formatter").finish()
+    }
+}


### PR DESCRIPTION
Closes #31 and #2 by using [`termcolor`](https://crates.io/crates/termcolor) to do the hard work.

# Colours

The default format now includes some colours:

![colours](https://user-images.githubusercontent.com/6721458/32217062-91f81d3e-be72-11e7-81e4-2e375c5826e8.png)

The colour API is still private because I'm not sure how we want to expose it.

# Buffering

This API goes back to buffering log records before printing them to the terminal, but we use a single buffer per thread rather than allocating for each log. I did some benchmarking and performance looks good overall.