### PR TITLE
Add rfc3339 timestamps to default format

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,7 @@ publish = false # this branch contains breaking changes
 log = { git = "https://github.com/rust-lang-nursery/log.git", features = ["std"] }
 regex = { version = "0.2", optional = true }
 termcolor = "0.3"
+chrono = "0.4"
 
 [[test]]
 name = "regexp_filter"

--- a/README.md
+++ b/README.md
@@ -95,11 +95,11 @@ $ RUST_LOG=my_lib=info cargo test
      Running target/debug/my_lib-...
 
 running 2 tests
-INFO:my_lib::tests: logging from another test
-INFO:my_lib: add_one called with -8
+INFO: 2017-11-01T21:37:57.073523133+00:00: my_lib::tests: logging from another test
+INFO: 2017-11-01T21:37:57.073523133+00:00: my_lib: add_one called with -8
 test tests::it_handles_negative_numbers ... ok
-INFO:my_lib::tests: can log from the test too
-INFO:my_lib: add_one called with 2
+INFO: 2017-11-01T21:37:57.073523133+00:00: my_lib::tests: can log from the test too
+INFO: 2017-11-01T21:37:57.073523133+00:00: my_lib: add_one called with 2
 test tests::it_adds_one ... ok
 
 test result: ok. 2 passed; 0 failed; 0 ignored; 0 measured
@@ -117,8 +117,8 @@ $ RUST_LOG=my_lib=info cargo test it_adds_one
      Running target/debug/my_lib-...
 
 running 1 test
-INFO:my_lib::tests: can log from the test too
-INFO:my_lib: add_one called with 2
+INFO: 2017-11-01T21:37:57.073523133+00:00: my_lib::tests: can log from the test too
+INFO: 2017-11-01T21:37:57.073523133+00:00: my_lib: add_one called with 2
 test tests::it_adds_one ... ok
 
 test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -37,37 +37,37 @@
 //!
 //! ```{.bash}
 //! $ RUST_LOG=error ./main
-//! ERROR:main: this is printed by default
+//! ERROR: 2017-11-01T21:37:57.073523133+00:00: main: this is printed by default
 //! ```
 //!
 //! ```{.bash}
 //! $ RUST_LOG=info ./main
-//! ERROR:main: this is printed by default
-//! INFO:main: the answer was: 12
+//! ERROR: 2017-11-01T21:37:57.073523133+00:00: main: this is printed by default
+//! INFO: 2017-11-01T21:37:57.073523133+00:00: main: the answer was: 12
 //! ```
 //!
 //! ```{.bash}
 //! $ RUST_LOG=debug ./main
-//! DEBUG:main: this is a debug message
-//! ERROR:main: this is printed by default
-//! INFO:main: the answer was: 12
+//! DEBUG: 2017-11-01T21:37:57.073523133+00:00: main: this is a debug message
+//! ERROR: 2017-11-01T21:37:57.073523133+00:00: main: this is printed by default
+//! INFO: 2017-11-01T21:37:57.073523133+00:00: main: the answer was: 12
 //! ```
 //!
 //! You can also set the log level on a per module basis:
 //!
 //! ```{.bash}
 //! $ RUST_LOG=main=info ./main
-//! ERROR:main: this is printed by default
-//! INFO:main: the answer was: 12
+//! ERROR: 2017-11-01T21:37:57.073523133+00:00: main: this is printed by default
+//! INFO: 2017-11-01T21:37:57.073523133+00:00: main: the answer was: 12
 //! ```
 //!
 //! And enable all logging:
 //!
 //! ```{.bash}
 //! $ RUST_LOG=main ./main
-//! DEBUG:main: this is a debug message
-//! ERROR:main: this is printed by default
-//! INFO:main: the answer was: 12
+//! DEBUG: 2017-11-01T21:37:57.073523133+00:00: main: this is a debug message
+//! ERROR: 2017-11-01T21:37:57.073523133+00:00: main: this is printed by default
+//! INFO: 2017-11-01T21:37:57.073523133+00:00: main: the answer was: 12
 //! ```
 //!
 //! See the documentation for the [`log` crate][log-crate-url] for more
@@ -143,6 +143,7 @@
 
 extern crate log;
 extern crate termcolor;
+extern crate chrono;
 
 use std::env;
 use std::io::prelude::*;
@@ -238,6 +239,7 @@ impl Builder {
         Builder {
             filter: filter::Builder::new(),
             format: Box::new(|buf, record| {
+                let ts = buf.timestamp();
                 let level = record.level();
                 let level_color = match level {
                     Level::Trace => Color::White,
@@ -248,7 +250,7 @@ impl Builder {
                 };
 
                 let write_level = write!(buf.color(level_color), "{}:", level);
-                let write_args = writeln!(buf, "{}: {}", record.module_path(), record.args());
+                let write_args = writeln!(buf, " {}: {}: {}", ts, record.module_path(), record.args());
 
                 write_level.and(write_args)
             }),


### PR DESCRIPTION
Closes #30 

Adds [RFC3339](https://tools.ietf.org/html/rfc3339) formatted timestamps to the default log format:

![timestamps](https://user-images.githubusercontent.com/6721458/32300605-0efc7ae4-bfa6-11e7-8026-5843c4149739.png)

I've made an effort to avoid allocating temporary strings or needing to parse a format for each log, so there's a currently private `Timestamp` struct that can be pulled off a `Formatter` that does this.