### PR TITLE
Allow custom timestamp formats.

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,11 +95,11 @@ $ RUST_LOG=my_lib=info cargo test
      Running target/debug/my_lib-...
 
 running 2 tests
-INFO: 2017-11-01T21:37:57.073523133+00:00: my_lib::tests: logging from another test
-INFO: 2017-11-01T21:37:57.073523133+00:00: my_lib: add_one called with -8
+INFO: 2017-11-01T21:37:57+00:00: my_lib::tests: logging from another test
+INFO: 2017-11-01T21:37:57+00:00: my_lib: add_one called with -8
 test tests::it_handles_negative_numbers ... ok
-INFO: 2017-11-01T21:37:57.073523133+00:00: my_lib::tests: can log from the test too
-INFO: 2017-11-01T21:37:57.073523133+00:00: my_lib: add_one called with 2
+INFO: 2017-11-01T21:37:57+00:00: my_lib::tests: can log from the test too
+INFO: 2017-11-01T21:37:57+00:00: my_lib: add_one called with 2
 test tests::it_adds_one ... ok
 
 test result: ok. 2 passed; 0 failed; 0 ignored; 0 measured
@@ -117,8 +117,8 @@ $ RUST_LOG=my_lib=info cargo test it_adds_one
      Running target/debug/my_lib-...
 
 running 1 test
-INFO: 2017-11-01T21:37:57.073523133+00:00: my_lib::tests: can log from the test too
-INFO: 2017-11-01T21:37:57.073523133+00:00: my_lib: add_one called with 2
+INFO: 2017-11-01T21:37:57+00:00: my_lib::tests: can log from the test too
+INFO: 2017-11-01T21:37:57+00:00: my_lib: add_one called with 2
 test tests::it_adds_one ... ok
 
 test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured


### PR DESCRIPTION
Past experience has taught me that you'll never have one logging time
format that pleases everyone, so perhaps we should just allow it to be
configurable. :)

We can use `StrftimeItems` to parse the format string once when we build
the `Logger`. We limit the lifetime of the format string to `'static` as
it keeps things simple. (If we wanted to accept arbitrary lifetimes,
I think we'd either need to introduce a lifetime parameter on `Logger`,
or have a self-referential struct somewhere).

This commit also removes the nanoseconds, as suggested in #34. It does
not alias `+00:00` to `+Z`, as there doesn't seem to be a way to do this
with `chrono::format::strftime`. (It is possible to do it by
constructing our own iterator of formatting `Item`s, but I think
`chrono` should learn to allow this via `StftimeItems` instead).