### PR TITLE
Make the timestamp format more compact

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ environment variable that corresponds with the log messages you want to show.
 
 ```bash
 $ RUST_LOG=info ./main
-starting up
+INFO: 2017-11-09T02:12:24Z: main: starting up
 ```
 
 ### In tests
@@ -95,11 +95,11 @@ $ RUST_LOG=my_lib=info cargo test
      Running target/debug/my_lib-...
 
 running 2 tests
-INFO: 2017-11-01T21:37:57.073523133+00:00: my_lib::tests: logging from another test
-INFO: 2017-11-01T21:37:57.073523133+00:00: my_lib: add_one called with -8
+INFO: 2017-11-09T02:12:24Z: my_lib::tests: logging from another test
+INFO: 2017-11-09T02:12:24Z: my_lib: add_one called with -8
 test tests::it_handles_negative_numbers ... ok
-INFO: 2017-11-01T21:37:57.073523133+00:00: my_lib::tests: can log from the test too
-INFO: 2017-11-01T21:37:57.073523133+00:00: my_lib: add_one called with 2
+INFO: 2017-11-09T02:12:24Z: my_lib::tests: can log from the test too
+INFO: 2017-11-09T02:12:24Z: my_lib: add_one called with 2
 test tests::it_adds_one ... ok
 
 test result: ok. 2 passed; 0 failed; 0 ignored; 0 measured
@@ -117,8 +117,8 @@ $ RUST_LOG=my_lib=info cargo test it_adds_one
      Running target/debug/my_lib-...
 
 running 1 test
-INFO: 2017-11-01T21:37:57.073523133+00:00: my_lib::tests: can log from the test too
-INFO: 2017-11-01T21:37:57.073523133+00:00: my_lib: add_one called with 2
+INFO: 2017-11-09T02:12:24Z: my_lib::tests: can log from the test too
+INFO: 2017-11-09T02:12:24Z: my_lib: add_one called with 2
 test tests::it_adds_one ... ok
 
 test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -37,37 +37,37 @@
 //!
 //! ```{.bash}
 //! $ RUST_LOG=error ./main
-//! ERROR: 2017-11-01T21:37:57.073523133+00:00: main: this is printed by default
+//! ERROR: 2017-11-09T02:12:24Z: main: this is printed by default
 //! ```
 //!
 //! ```{.bash}
 //! $ RUST_LOG=info ./main
-//! ERROR: 2017-11-01T21:37:57.073523133+00:00: main: this is printed by default
-//! INFO: 2017-11-01T21:37:57.073523133+00:00: main: the answer was: 12
+//! ERROR: 2017-11-09T02:12:24Z: main: this is printed by default
+//! INFO: 2017-11-09T02:12:24Z: main: the answer was: 12
 //! ```
 //!
 //! ```{.bash}
 //! $ RUST_LOG=debug ./main
-//! DEBUG: 2017-11-01T21:37:57.073523133+00:00: main: this is a debug message
-//! ERROR: 2017-11-01T21:37:57.073523133+00:00: main: this is printed by default
-//! INFO: 2017-11-01T21:37:57.073523133+00:00: main: the answer was: 12
+//! DEBUG: 2017-11-09T02:12:24Z: main: this is a debug message
+//! ERROR: 2017-11-09T02:12:24Z: main: this is printed by default
+//! INFO: 2017-11-09T02:12:24Z: main: the answer was: 12
 //! ```
 //!
 //! You can also set the log level on a per module basis:
 //!
 //! ```{.bash}
 //! $ RUST_LOG=main=info ./main
-//! ERROR: 2017-11-01T21:37:57.073523133+00:00: main: this is printed by default
-//! INFO: 2017-11-01T21:37:57.073523133+00:00: main: the answer was: 12
+//! ERROR: 2017-11-09T02:12:24Z: main: this is printed by default
+//! INFO: 2017-11-09T02:12:24Z: main: the answer was: 12
 //! ```
 //!
 //! And enable all logging:
 //!
 //! ```{.bash}
 //! $ RUST_LOG=main ./main
-//! DEBUG: 2017-11-01T21:37:57.073523133+00:00: main: this is a debug message
-//! ERROR: 2017-11-01T21:37:57.073523133+00:00: main: this is printed by default
-//! INFO: 2017-11-01T21:37:57.073523133+00:00: main: the answer was: 12
+//! DEBUG: 2017-11-09T02:12:24Z: main: this is a debug message
+//! ERROR: 2017-11-09T02:12:24Z: main: this is printed by default
+//! INFO: 2017-11-09T02:12:24Z: main: the answer was: 12
 //! ```
 //!
 //! See the documentation for the [`log` crate][log-crate-url] for more


### PR DESCRIPTION
Fixes #34 

![format](https://user-images.githubusercontent.com/6721458/32585128-a62102e0-c547-11e7-98ed-6cebe1007d12.png)

Makes the RFC3339 timestamp format more compact. This is still just using a hardcoded set of `chrono::format::Item`s. I think we'll definitely want to make this configurable in the future somehow.