### PR TITLE
Upgrade to log 0.4.0-rc.1

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "env_logger"
-version = "0.4.3" # remember to update html_root_url
+version = "0.5.0-rc.1" # remember to update html_root_url
 authors = ["The Rust Project Developers"]
 license = "MIT/Apache-2.0"
 readme = "README.md"
@@ -15,7 +15,7 @@ keywords = ["logging", "log", "logger"]
 publish = false # this branch contains breaking changes
 
 [dependencies]
-log = { git = "https://github.com/rust-lang-nursery/log.git", features = ["std"] }
+log = { version = "0.4.0-rc.1", features = ["std"] }
 regex = { version = "0.2", optional = true }
 termcolor = "0.3"
 chrono = "0.4"

--- a/README.md
+++ b/README.md
@@ -17,8 +17,8 @@ It must be added along with `log` to the project dependencies:
 
 ```toml
 [dependencies]
-log = "0.3"
-env_logger = "0.3"
+log = "0.4.0-rc.1"
+env_logger = "0.5.0-rc.1"
 ```
 
 `env_logger` must be initialized as early as possible in the project. After it's initialized, you can use the `log` macros to do actual logging.
@@ -51,10 +51,10 @@ Tests can use the `env_logger` crate to see log messages generated during that t
 
 ```toml
 [dependencies]
-log = "0.3"
+log = "0.4.0-rc.1"
 
 [dev-dependencies]
-env_logger = "0.3"
+env_logger = "0.5.0-rc.1"
 ```
 
 ```rust

--- a/examples/custom_logger.rs
+++ b/examples/custom_logger.rs
@@ -37,11 +37,10 @@ impl MyLogger {
     }
 
     fn init() -> Result<(), SetLoggerError> {
-        log::set_boxed_logger(|max_level| {
-            let logger = Self::new();
-            max_level.set(logger.inner.filter());
-            Box::new(logger)
-        })
+        let logger = Self::new();
+
+        log::set_max_level(logger.inner.filter());
+        log::set_boxed_logger(Box::new(logger))
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -375,11 +375,10 @@ impl Logger {
     /// use env_logger::Logger;
     ///
     /// fn main() {
-    ///     log::set_boxed_logger(|max_level| {
-    ///         let logger = Logger::new();
-    ///         max_level.set(logger.filter());
-    ///         Box::new(logger)
-    ///     });
+    ///     let logger = Logger::new();
+    /// 
+    ///     log::set_max_level(logger.filter());
+    ///     log::set_boxed_logger(Box::new(logger));
     /// }
     /// ```
     ///
@@ -409,11 +408,10 @@ impl Logger {
     /// use env_logger::Logger;
     ///
     /// fn main() {
-    ///     log::set_boxed_logger(|max_level| {
-    ///         let logger = Logger::from_env("MY_LOG");
-    ///         max_level.set(logger.filter());
-    ///         Box::new(logger)
-    ///     });
+    ///     let logger = Logger::from_env("MY_LOG");
+    /// 
+    ///     log::set_max_level(logger.filter());
+    ///     log::set_boxed_logger(Box::new(logger));
     /// }
     /// ```
     ///


### PR DESCRIPTION
- Fixes up the build after some changes to `log`
- Targets the new RC version of `log`
- Specifies an RC version for `env_logger`

The goal would be to get this up on crates.io sooner rather than later so we can loosely follow `log`'s own path to a stable `0.4` release.