### PR TITLE
Pad log level so output is more aligned

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -249,7 +249,7 @@ impl Builder {
                     Level::Error => Color::Red,
                 };
 
-                let write_level = write!(buf.color(level_color), "{}:", level);
+                let write_level = write!(buf.color(level_color), "{:>5}:", level);
                 let write_args = if let Some(module_path) = record.module_path() {
                     writeln!(buf, " {}: {}: {}", ts, module_path, record.args())
                 }


### PR DESCRIPTION
This makes the example print this:

```
TRACE: 2017-12-07T13:44:04Z: default: some trace log
DEBUG: 2017-12-07T13:44:04Z: default: some debug log
 INFO: 2017-12-07T13:44:04Z: default: some information log
 WARN: 2017-12-07T13:44:04Z: default: some warning log
ERROR: 2017-12-07T13:44:04Z: default: some error log
```