### PR TITLE
Public color API

### DIFF
--- a/examples/custom_format.rs
+++ b/examples/custom_format.rs
@@ -7,10 +7,11 @@ Before running this example, try setting the `MY_LOG_LEVEL` environment variable
 $ export MY_LOG_LEVEL='info'
 ```
 
-Also try setting the `MY_LOG_STYLE` environment variable to `0` to disable colors:
+Also try setting the `MY_LOG_STYLE` environment variable to `never` to disable colors
+or `auto` to enable them:
 
 ```no_run,shell
-$ export MY_LOG_STYLE=0
+$ export MY_LOG_STYLE=never
 ```
 
 If you want to control the logging output completely, see the `custom_logger` example.

--- a/examples/custom_format.rs
+++ b/examples/custom_format.rs
@@ -17,12 +17,19 @@ extern crate env_logger;
 use std::env;
 use std::io::Write;
 
+use env_logger::{Builder, fmt};
+
 fn init_logger() {
-    let mut builder = env_logger::Builder::new();
+    let mut builder = Builder::new();
 
     // Use a different format for writing log records
     builder.format(|buf, record| {
-        writeln!(buf, "My formatted log: {}", record.args())
+        let mut style = buf.style();
+        style.set_bg(fmt::Color::Yellow).set_bold(true);
+
+        let timestamp = buf.timestamp();
+
+        writeln!(buf, "My formatted log ({}): {}", timestamp, style.value(record.args()))
     });
 
     if let Ok(s) = env::var("MY_LOG_LEVEL") {

--- a/examples/custom_format.rs
+++ b/examples/custom_format.rs
@@ -4,13 +4,13 @@ Changing the default logging format.
 Before running this example, try setting the `MY_LOG_LEVEL` environment variable to `info`:
 
 ```no_run,shell
-$ export MY_LOG_LEVEL = 'info'
+$ export MY_LOG_LEVEL='info'
 ```
 
 Also try setting the `MY_LOG_STYLE` environment variable to `0` to disable colors:
 
 ```no_run,shell
-$ export MY_LOG_STYLE = 0
+$ export MY_LOG_STYLE=0
 ```
 
 If you want to control the logging output completely, see the `custom_logger` example.

--- a/examples/custom_format.rs
+++ b/examples/custom_format.rs
@@ -20,7 +20,6 @@ If you want to control the logging output completely, see the `custom_logger` ex
 extern crate log;
 extern crate env_logger;
 
-use std::env;
 use std::io::Write;
 
 use env_logger::{Env, Builder, fmt};

--- a/examples/custom_format.rs
+++ b/examples/custom_format.rs
@@ -7,6 +7,12 @@ Before running this example, try setting the `MY_LOG_LEVEL` environment variable
 $ export MY_LOG_LEVEL = 'info'
 ```
 
+Also try setting the `MY_LOG_STYLE` environment variable to `0` to disable colors:
+
+```no_run,shell
+$ export MY_LOG_STYLE = 0
+```
+
 If you want to control the logging output completely, see the `custom_logger` example.
 */
 
@@ -17,10 +23,14 @@ extern crate env_logger;
 use std::env;
 use std::io::Write;
 
-use env_logger::{Builder, fmt};
+use env_logger::{Env, Builder, fmt};
 
 fn init_logger() {
-    let mut builder = Builder::new();
+    let env = Env::default()
+        .filter("MY_LOG_LEVEL")
+        .write_style("MY_LOG_STYLE");
+
+    let mut builder = Builder::from_env(env);
 
     // Use a different format for writing log records
     builder.format(|buf, record| {
@@ -31,10 +41,6 @@ fn init_logger() {
 
         writeln!(buf, "My formatted log ({}): {}", timestamp, style.value(record.args()))
     });
-
-    if let Ok(s) = env::var("MY_LOG_LEVEL") {
-        builder.parse(&s);
-    }
 
     builder.init();
 }

--- a/examples/custom_logger.rs
+++ b/examples/custom_logger.rs
@@ -7,10 +7,11 @@ Before running this example, try setting the `MY_LOG_LEVEL` environment variable
 $ export MY_LOG_LEVEL='info'
 ```
 
-Also try setting the `RUST_LOG_STYLE` environment variable to `0` to disable colors:
+Also try setting the `MY_LOG_STYLE` environment variable to `never` to disable colors
+or `auto` to enable them:
 
 ```no_run,shell
-$ export RUST_LOG_STYLE=0
+$ export MY_LOG_STYLE=never
 ```
 
 If you only want to change the way logs are formatted, look at the `custom_format` example.

--- a/examples/custom_logger.rs
+++ b/examples/custom_logger.rs
@@ -7,6 +7,12 @@ Before running this example, try setting the `MY_LOG_LEVEL` environment variable
 $ export MY_LOG_LEVEL = 'info'
 ```
 
+Also try setting the `RUST_LOG_STYLE` environment variable to `0` to disable colors:
+
+```no_run,shell
+$ export RUST_LOG_STYLE = 0
+```
+
 If you only want to change the way logs are formatted, look at the `custom_format` example.
 */
 
@@ -23,13 +29,7 @@ struct MyLogger {
 impl MyLogger {
     fn new() -> MyLogger {
         use env_logger::filter::Builder;
-        let mut builder = Builder::new();
-
-        // Parse a directives string from an environment variable
-        // This uses the same format as `env_logger::Logger`
-        if let Ok(ref filter) = std::env::var("MY_LOG_LEVEL") {
-           builder.parse(filter);
-        }
+        let mut builder = Builder::from_env("MY_LOG_LEVEL");
 
         MyLogger {
             inner: builder.build()

--- a/examples/custom_logger.rs
+++ b/examples/custom_logger.rs
@@ -4,13 +4,13 @@ Using `env_logger` to drive a custom logger.
 Before running this example, try setting the `MY_LOG_LEVEL` environment variable to `info`:
 
 ```no_run,shell
-$ export MY_LOG_LEVEL = 'info'
+$ export MY_LOG_LEVEL='info'
 ```
 
 Also try setting the `RUST_LOG_STYLE` environment variable to `0` to disable colors:
 
 ```no_run,shell
-$ export RUST_LOG_STYLE = 0
+$ export RUST_LOG_STYLE=0
 ```
 
 If you only want to change the way logs are formatted, look at the `custom_format` example.

--- a/examples/default.rs
+++ b/examples/default.rs
@@ -4,13 +4,13 @@ Using `env_logger`.
 Before running this example, try setting the `MY_LOG_LEVEL` environment variable to `info`:
 
 ```no_run,shell
-$ export MY_LOG_LEVEL = 'info'
+$ export MY_LOG_LEVEL='info'
 ```
 
 Also try setting the `RUST_LOG_STYLE` environment variable to `0` to disable colors:
 
 ```no_run,shell
-$ export RUST_LOG_STYLE = 0
+$ export RUST_LOG_STYLE=0
 ```
 */
 

--- a/examples/default.rs
+++ b/examples/default.rs
@@ -7,10 +7,11 @@ Before running this example, try setting the `MY_LOG_LEVEL` environment variable
 $ export MY_LOG_LEVEL='info'
 ```
 
-Also try setting the `RUST_LOG_STYLE` environment variable to `0` to disable colors:
+Also try setting the `MY_LOG_STYLE` environment variable to `never` to disable colors
+or `auto` to enable them:
 
 ```no_run,shell
-$ export RUST_LOG_STYLE=0
+$ export MY_LOG_STYLE=never
 ```
 */
 

--- a/examples/default.rs
+++ b/examples/default.rs
@@ -6,6 +6,12 @@ Before running this example, try setting the `MY_LOG_LEVEL` environment variable
 ```no_run,shell
 $ export MY_LOG_LEVEL = 'info'
 ```
+
+Also try setting the `RUST_LOG_STYLE` environment variable to `0` to disable colors:
+
+```no_run,shell
+$ export RUST_LOG_STYLE = 0
+```
 */
 
 #[macro_use]

--- a/src/filter/mod.rs
+++ b/src/filter/mod.rs
@@ -252,6 +252,12 @@ impl Builder {
     }
 }
 
+impl Default for Builder {
+    fn default() -> Self {
+        Builder::new()
+    }
+}
+
 impl fmt::Debug for Filter {
     fn fmt(&self, f: &mut fmt::Formatter)->fmt::Result {
         f.debug_struct("Filter")

--- a/src/filter/mod.rs
+++ b/src/filter/mod.rs
@@ -59,6 +59,7 @@
 //! [`Builder::parse`]: struct.Builder.html#method.parse
 //! [`Filter::matches`]: struct.Filter.html#method.matches
 
+use std::env;
 use std::mem;
 use std::fmt;
 use log::{Level, LevelFilter, Record, Metadata};
@@ -183,6 +184,17 @@ impl Builder {
             directives: Vec::new(),
             filter: None,
         }
+    }
+
+    /// Initializes the filter builder from an environment.
+    pub fn from_env(env: &str) -> Builder {
+        let mut builder = Builder::new();
+
+        if let Ok(s) = env::var(env) {
+            builder.parse(&s);
+        }
+
+        builder
     }
 
     /// Adds a directive to the filter.

--- a/src/fmt.rs
+++ b/src/fmt.rs
@@ -519,13 +519,27 @@ mod tests {
     #[test]
     fn parse_write_style_valid() {
         let inputs = vec![
-            ("auto", Some(WriteStyle::Auto)),
-            ("always", Some(WriteStyle::Always)),
-            ("never", Some(WriteStyle::Never)),
+            ("auto", WriteStyle::Auto),
+            ("always", WriteStyle::Always),
+            ("never", WriteStyle::Never),
         ];
 
         for (input, expected) in inputs {
-            assert_eq!(expected, WriteStyle::parse(input));
+            assert_eq!(expected, parse_write_style(input));
+        }
+    }
+
+    #[test]
+    fn parse_write_style_invalid() {
+        let inputs = vec![
+            "",
+            "true",
+            "false",
+            "NEVER!!"
+        ];
+
+        for input in inputs {
+            assert_eq!(WriteStyle::Auto, parse_write_style(input));
         }
     }
 }

--- a/src/fmt.rs
+++ b/src/fmt.rs
@@ -11,97 +11,175 @@
 use std::io::prelude::*;
 use std::io;
 use std::fmt;
+use std::rc::Rc;
+use std::cell::RefCell;
 
-use termcolor::{Color, ColorSpec, Buffer, WriteColor};
+use termcolor::{ColorSpec, Buffer, BufferWriter, WriteColor};
 use chrono::{DateTime, Utc};
 use chrono::format::Item;
+
+pub use termcolor::Color;
 
 /// A formatter to write logs into.
 /// 
 /// `Formatter` implements the standard [`Write`] trait for writing log records.
-/// It also supports terminal colors, but this is currently private.
+/// It also supports terminal colors, through the [`style`] method.
 /// 
 /// [`Write`]: https://doc.rust-lang.org/stable/std/io/trait.Write.html
+/// [`style`]: #method.style
 pub struct Formatter {
-    buf: Buffer,
+    buf: Rc<RefCell<Buffer>>,
 }
 
-/// A formatter with a particular style.
-/// 
-/// Each call to `write` will apply the style before writing the output.
-pub(crate) struct StyledFormatter<W> {
-    buf: W,
+/// A set of styles to apply to the terminal output.
+#[derive(Clone)]
+pub struct Style {
+    buf: Rc<RefCell<Buffer>>,
     spec: ColorSpec,
 }
 
+/// A value that can be printed using the given styles.
+pub struct StyledValue<'a, T> {
+    style: &'a Style,
+    value: T,
+}
+
+impl Style {
+    /// Set the foreground color.
+    pub fn set_color(&mut self, color: Color) -> &mut Style {
+        self.spec.set_fg(Some(color));
+        self
+    }
+
+    /// Make the text bold.
+    pub fn set_bold(&mut self, yes: bool) -> &mut Style {
+        self.spec.set_bold(yes);
+        self
+    }
+
+    /// Set the background color.
+    pub fn set_bg(&mut self, color: Color) -> &mut Style {
+        self.spec.set_bg(Some(color));
+        self
+    }
+
+    /// Wrap a value in the style.
+    /// 
+    /// The same `Style` can be used to print multiple different values.
+    pub fn value<T>(&self, value: T) -> StyledValue<T> {
+        StyledValue {
+            style: &self,
+            value
+        }
+    }
+}
+
 /// An RFC3339 formatted timestamp.
-pub(crate) struct Timestamp(DateTime<Utc>);
+/// 
+/// The timestamp implements [`Display`] and can be written to a [`Formatter`].
+/// 
+/// [`Display`]: https://doc.rust-lang.org/stable/std/fmt/trait.Display.html
+/// [`Formatter`]: struct.Formatter.html
+pub struct Timestamp(DateTime<Utc>);
 
 impl Formatter {
     pub(crate) fn new(buf: Buffer) -> Self {
         Formatter {
-            buf: buf,
+            buf: Rc::new(RefCell::new(buf)),
         }
     }
 
-    pub(crate) fn color(&mut self, color: Color) -> StyledFormatter<&mut Buffer> {
-        let mut spec = ColorSpec::new();
-        spec.set_fg(Some(color));
-
-        StyledFormatter {
-            buf: &mut self.buf,
-            spec: spec
+    /// Begin a new style.
+    pub fn style(&self) -> Style {
+        Style {
+            buf: self.buf.clone(),
+            spec: ColorSpec::new(),
         }
     }
 
-    pub(crate) fn timestamp(&self) -> Timestamp {
+    /// Get a timestamp.
+    pub fn timestamp(&self) -> Timestamp {
         Timestamp(Utc::now())
     }
 
-    pub(crate) fn as_ref(&self) -> &Buffer {
-        &self.buf
+    pub(crate) fn print(&self, writer: &BufferWriter) -> io::Result<()> {
+        writer.print(&self.buf.borrow())
     }
 
     pub(crate) fn clear(&mut self) {
-        self.buf.clear()
+        self.buf.borrow_mut().clear()
     }
 }
 
 impl Write for Formatter {
     fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
-        self.buf.write(buf)
+        self.buf.borrow_mut().write(buf)
     }
 
     fn flush(&mut self) -> io::Result<()> {
-        self.buf.flush()
+        self.buf.borrow_mut().flush()
     }
 }
 
-impl<W> Write for StyledFormatter<W>
-    where W: WriteColor
-{
-    fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
-        self.buf.set_color(&self.spec)?;
+impl<'a, T> StyledValue<'a, T> {
+    fn write_fmt<F>(&self, f: F) -> fmt::Result
+    where
+        F: FnOnce() -> fmt::Result,
+    {
+        self.style.buf.borrow_mut().set_color(&self.style.spec).map_err(|_| fmt::Error)?;
 
         // Always try to reset the terminal style, even if writing failed
-        let write = self.buf.write(buf);
-        let reset = self.buf.reset();
+        let write = f();
+        let reset = self.style.buf.borrow_mut().reset().map_err(|_| fmt::Error);
 
-        write.and_then(|w| reset.map(|_| w))
-    }
-
-    fn flush(&mut self) -> io::Result<()> {
-        self.buf.flush()
+        write.and(reset)
     }
 }
 
-impl fmt::Debug for Formatter{
+impl fmt::Debug for Timestamp {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        /// A `Debug` wrapper for `Timestamp` that uses the `Display` implementation.
+        struct TimestampValue<'a>(&'a Timestamp);
+
+        impl<'a> fmt::Debug for TimestampValue<'a> {
+            fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+                fmt::Display::fmt(&self.0, f)
+            }
+        }
+
+        f.debug_tuple("Timestamp")
+         .field(&TimestampValue(&self))
+         .finish()
+    }
+}
+
+impl fmt::Debug for Formatter {
     fn fmt(&self, f: &mut fmt::Formatter)->fmt::Result {
         f.debug_struct("Formatter").finish()
     }
 }
 
-impl fmt::Display for Timestamp{
+impl fmt::Debug for Style {
+    fn fmt(&self, f: &mut fmt::Formatter)->fmt::Result {
+        f.debug_struct("Style").field("spec", &self.spec).finish()
+    }
+}
+
+impl<'a, T: fmt::Debug> fmt::Debug for StyledValue<'a, T> {
+    fn fmt(&self, f: &mut fmt::Formatter)->fmt::Result {
+        self.write_fmt(|| T::fmt(&self.value, f))
+    }
+}
+
+impl<'a, T: fmt::Display> fmt::Display for StyledValue<'a, T> {
+    fn fmt(&self, f: &mut fmt::Formatter)->fmt::Result {
+        self.write_fmt(|| T::fmt(&self.value, f))
+    }
+}
+
+// TODO: Other `fmt` traits
+
+impl fmt::Display for Timestamp {
     fn fmt(&self, f: &mut fmt::Formatter)->fmt::Result {
         const ITEMS: &'static [Item<'static>] = {
             use chrono::format::Item::*;

--- a/src/fmt.rs
+++ b/src/fmt.rs
@@ -25,13 +25,77 @@ pub use termcolor::Color;
 /// `Formatter` implements the standard [`Write`] trait for writing log records.
 /// It also supports terminal colors, through the [`style`] method.
 /// 
+/// # Examples
+/// 
+/// Use the [`writeln`] macro to easily format a log record:
+/// 
+/// ```
+/// use std::io::Write;
+/// 
+/// let mut builder = env_logger::Builder::new();
+/// 
+/// builder.format(|buf, record| writeln!(buf, "{}: {}", record.level(), record.args()));
+/// ```
+/// 
 /// [`Write`]: https://doc.rust-lang.org/stable/std/io/trait.Write.html
+/// [`writeln`]: https://doc.rust-lang.org/stable/std/macro.writeln.html
 /// [`style`]: #method.style
 pub struct Formatter {
     buf: Rc<RefCell<Buffer>>,
 }
 
 /// A set of styles to apply to the terminal output.
+/// 
+/// Call [`Formatter.style`] to get a `Style` and use the builder methods to 
+/// set styling properties, like [color] and [weight].
+/// To print a value using the style, wrap it in a call to [`value`] when the log
+/// record is formatted.
+/// 
+/// # Examples
+/// 
+/// Create a bold, red colored style and use it to print the log level:
+/// 
+/// ```
+/// use std::io::Write;
+/// use env_logger::fmt::Color;
+/// 
+/// let mut builder = env_logger::Builder::new();
+/// 
+/// builder.format(|buf, record| {
+///     let mut level_style = buf.style();
+/// 
+///     level_style.set_color(Color::Red).set_bold(true);
+/// 
+///     writeln!(buf, "{}: {}",
+///         level_style.value(record.level()),
+///         record.args())
+/// });
+/// ```
+/// 
+/// Styles can be re-used to output multiple values:
+/// 
+/// ```
+/// use std::io::Write;
+/// use env_logger::fmt::Color;
+/// 
+/// let mut builder = env_logger::Builder::new();
+/// 
+/// builder.format(|buf, record| {
+///     let mut bold = buf.style();
+/// 
+///     bold.set_bold(true);
+/// 
+///     writeln!(buf, "{}: {} {}",
+///         bold.value(record.level()),
+///         bold.value("some bold text"),
+///         record.args())
+/// });
+/// ```
+/// 
+/// [`Formatter.style`]: struct.Formatter.html#method.style
+/// [color]: #method.color
+/// [weight]: #method.weight
+/// [`value`]: #method.value
 #[derive(Clone)]
 pub struct Style {
     buf: Rc<RefCell<Buffer>>,
@@ -39,25 +103,88 @@ pub struct Style {
 }
 
 /// A value that can be printed using the given styles.
+/// 
+/// It is the result of calling [`Style.value`].
+/// 
+/// [`Style.value`]: struct.Style.html#method.value
 pub struct StyledValue<'a, T> {
     style: &'a Style,
     value: T,
 }
 
 impl Style {
-    /// Set the foreground color.
+    /// Set the text color.
+    /// 
+    /// # Examples
+    /// 
+    /// Create a style with red text:
+    /// 
+    /// ```
+    /// use std::io::Write;
+    /// use env_logger::fmt::Color;
+    /// 
+    /// let mut builder = env_logger::Builder::new();
+    /// 
+    /// builder.format(|buf, record| {
+    ///     let mut style = buf.style();
+    /// 
+    ///     style.set_color(Color::Red);
+    /// 
+    ///     writeln!(buf, "{}", style.value(record.args()))
+    /// });
+    /// ```
     pub fn set_color(&mut self, color: Color) -> &mut Style {
         self.spec.set_fg(Some(color));
         self
     }
 
-    /// Make the text bold.
+    /// Set the text weight.
+    /// 
+    /// If `yes` is true then text will be written in bold.
+    /// If `yes` is false then text will be written in the default weight.
+    /// 
+    /// # Examples
+    /// 
+    /// Create a style with bold text:
+    /// 
+    /// ```
+    /// use std::io::Write;
+    /// 
+    /// let mut builder = env_logger::Builder::new();
+    /// 
+    /// builder.format(|buf, record| {
+    ///     let mut style = buf.style();
+    /// 
+    ///     style.set_bold(true);
+    /// 
+    ///     writeln!(buf, "{}", style.value(record.args()))
+    /// });
+    /// ```
     pub fn set_bold(&mut self, yes: bool) -> &mut Style {
         self.spec.set_bold(yes);
         self
     }
 
     /// Set the background color.
+    /// 
+    /// # Examples
+    /// 
+    /// Create a style with a yellow background:
+    /// 
+    /// ```
+    /// use std::io::Write;
+    /// use env_logger::fmt::Color;
+    /// 
+    /// let mut builder = env_logger::Builder::new();
+    /// 
+    /// builder.format(|buf, record| {
+    ///     let mut style = buf.style();
+    /// 
+    ///     style.set_bg(Color::Yellow);
+    /// 
+    ///     writeln!(buf, "{}", style.value(record.args()))
+    /// });
+    /// ```
     pub fn set_bg(&mut self, color: Color) -> &mut Style {
         self.spec.set_bg(Some(color));
         self
@@ -66,6 +193,27 @@ impl Style {
     /// Wrap a value in the style.
     /// 
     /// The same `Style` can be used to print multiple different values.
+    /// 
+    /// # Examples
+    /// 
+    /// Create a bold, red colored style and use it to print the log level:
+    /// 
+    /// ```
+    /// use std::io::Write;
+    /// use env_logger::fmt::Color;
+    /// 
+    /// let mut builder = env_logger::Builder::new();
+    /// 
+    /// builder.format(|buf, record| {
+    ///     let mut style = buf.style();
+    /// 
+    ///     style.set_color(Color::Red).set_bold(true);
+    /// 
+    ///     writeln!(buf, "{}: {}",
+    ///         style.value(record.level()),
+    ///         record.args())
+    /// });
+    /// ```
     pub fn value<T>(&self, value: T) -> StyledValue<T> {
         StyledValue {
             style: &self,
@@ -74,10 +222,11 @@ impl Style {
     }
 }
 
-/// An RFC3339 formatted timestamp.
+/// An [RFC3339] formatted timestamp.
 /// 
 /// The timestamp implements [`Display`] and can be written to a [`Formatter`].
 /// 
+/// [RFC3339]: https://www.ietf.org/rfc/rfc3339.txt
 /// [`Display`]: https://doc.rust-lang.org/stable/std/fmt/trait.Display.html
 /// [`Formatter`]: struct.Formatter.html
 pub struct Timestamp(DateTime<Utc>);
@@ -89,7 +238,30 @@ impl Formatter {
         }
     }
 
-    /// Begin a new style.
+    /// Begin a new [`Style`].
+    /// 
+    /// # Examples
+    /// 
+    /// Create a bold, red colored style and use it to print the log level:
+    /// 
+    /// ```
+    /// use std::io::Write;
+    /// use env_logger::fmt::Color;
+    /// 
+    /// let mut builder = env_logger::Builder::new();
+    /// 
+    /// builder.format(|buf, record| {
+    ///     let mut level_style = buf.style();
+    /// 
+    ///     level_style.set_color(Color::Red).set_bold(true);
+    /// 
+    ///     writeln!(buf, "{}: {}",
+    ///         level_style.value(record.level()),
+    ///         record.args())
+    /// });
+    /// ```
+    /// 
+    /// [`Style`]: struct.Style.html
     pub fn style(&self) -> Style {
         Style {
             buf: self.buf.clone(),
@@ -97,7 +269,25 @@ impl Formatter {
         }
     }
 
-    /// Get a timestamp.
+    /// Get a [`Timestamp`] for the current date and time in UTC.
+    /// 
+    /// # Examples
+    /// 
+    /// Include the current timestamp with the log record:
+    /// 
+    /// ```
+    /// use std::io::Write;
+    /// 
+    /// let mut builder = env_logger::Builder::new();
+    /// 
+    /// builder.format(|buf, record| {
+    ///     let ts = buf.timestamp();
+    /// 
+    ///     writeln!(buf, "{}: {}: {}", ts, record.level(), record.args())
+    /// });
+    /// ```
+    /// 
+    /// [`Timestamp`]: struct.Timestamp.html
     pub fn timestamp(&self) -> Timestamp {
         Timestamp(Utc::now())
     }
@@ -165,19 +355,28 @@ impl fmt::Debug for Style {
     }
 }
 
-impl<'a, T: fmt::Debug> fmt::Debug for StyledValue<'a, T> {
-    fn fmt(&self, f: &mut fmt::Formatter)->fmt::Result {
-        self.write_fmt(|| T::fmt(&self.value, f))
-    }
+macro_rules! impl_styled_value_fmt {
+    ($($fmt_trait:path),*) => {
+        $(
+            impl<'a, T: $fmt_trait> $fmt_trait for StyledValue<'a, T> {
+                fn fmt(&self, f: &mut fmt::Formatter)->fmt::Result {
+                    self.write_fmt(|| T::fmt(&self.value, f))
+                }
+            }
+        )*
+    };
 }
 
-impl<'a, T: fmt::Display> fmt::Display for StyledValue<'a, T> {
-    fn fmt(&self, f: &mut fmt::Formatter)->fmt::Result {
-        self.write_fmt(|| T::fmt(&self.value, f))
-    }
-}
-
-// TODO: Other `fmt` traits
+impl_styled_value_fmt!(
+    fmt::Debug,
+    fmt::Display,
+    fmt::Pointer,
+    fmt::Octal,
+    fmt::Binary,
+    fmt::UpperHex,
+    fmt::LowerHex,
+    fmt::UpperExp,
+    fmt::LowerExp);
 
 impl fmt::Display for Timestamp {
     fn fmt(&self, f: &mut fmt::Formatter)->fmt::Result {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -114,11 +114,6 @@
 //! logged if it matches. Note that the matching is done after formatting the
 //! log string but before adding any logging meta-data. There is a single filter
 //! for all modules.
-//! 
-//! ## Disabling colors
-//! 
-//! Colors and other styles can be disabled by setting the `RUST_LOG_STYLE`
-//! environment variable to `0`.
 //!
 //! Some examples:
 //!
@@ -131,6 +126,11 @@
 //! * `error,hello=warn/[0-9]scopes` turn on global error logging and also
 //!   warn for hello. In both cases the log message must include a single digit
 //!   number followed by 'scopes'.
+//! 
+//! ## Disabling colors
+//! 
+//! Colors and other styles can be disabled by setting the `RUST_LOG_STYLE`
+//! environment variable to `0`.
 //!
 //! [log-crate-url]: https://docs.rs/log/
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -130,13 +130,14 @@
 //! ## Disabling colors
 //! 
 //! Colors and other styles can be configured with the `RUST_LOG_STYLE`
-//! environment variable.
-//! It accepts the following values:
+//! environment variable. It accepts the following values:
 //! 
 //! * `auto` (default) will attempt to print style characters, but don't force the issue.
+//! If the console isn't available on Windows, or if TERM=dumb, for example, then don't print colors.
 //! * `always` will always print style characters even if they aren't supported by the terminal.
+//! This includes emitting ANSI colors on Windows if the console API is unavailable.
 //! * `never` will never print style characters.
-//!
+//! 
 //! [log-crate-url]: https://docs.rs/log/
 
 #![doc(html_logo_url = "http://www.rust-lang.org/logos/rust-logo-128x128-blk-v2.png",
@@ -281,6 +282,32 @@ impl Builder {
     }
 
     /// Initializes the log builder from the environment.
+    /// 
+    /// The variables used to read configuration from can be tweaked before
+    /// passing in.
+    /// 
+    /// # Examples
+    /// 
+    /// Initialise a logger using the default environment variables:
+    /// 
+    /// ```
+    /// use env_logger::{Builder, Env};
+    /// 
+    /// let mut builder = Builder::from_env(Env::default());
+    /// builder.init();
+    /// ```
+    /// 
+    /// Initialise a logger using the `MY_LOG` variable for filtering and
+    /// `MY_LOG_STYLE` for whether or not to write styles:
+    /// 
+    /// ```
+    /// use env_logger::{Builder, Env};
+    /// 
+    /// let env = Env::new().filter("MY_LOG").write_style("MY_LOG_STYLE");
+    /// 
+    /// let mut builder = Builder::from_env(env);
+    /// builder.init();
+    /// ```
     pub fn from_env<'a, E>(env: E) -> Self
     where
         E: Into<Env<'a>>
@@ -564,10 +591,29 @@ pub fn init() {
 }
 
 /// Attempts to initialize the global logger with an env logger from the given
-/// environment variable.
+/// environment variables.
 ///
 /// This should be called early in the execution of a Rust program. Any log
 /// events that occur before initialization will be ignored.
+/// 
+/// # Examples
+/// 
+/// Initialise a logger using the `MY_LOG` environment variable for filters
+/// and `MY_LOG_STYLE` for writing colors:
+/// 
+/// ```
+/// # extern crate env_logger;
+/// use env_logger::{Builder, Env};
+/// 
+/// # fn run() -> Result<(), Box<::std::error::Error>> {
+/// let env = Env::new().filter("MY_LOG").write_style("MY_LOG_STYLE");
+/// 
+/// env_logger::try_init_from_env(env)?;
+/// 
+/// Ok(())
+/// # }
+/// # fn main() { run().unwrap(); }
+/// ```
 ///
 /// # Errors
 ///
@@ -583,10 +629,23 @@ where
 }
 
 /// Initializes the global logger with an env logger from the given environment
-/// variable.
+/// variables.
 ///
 /// This should be called early in the execution of a Rust program. Any log
 /// events that occur before initialization will be ignored.
+/// 
+/// # Examples
+/// 
+/// Initialise a logger using the `MY_LOG` environment variable for filters
+/// and `MY_LOG_STYLE` for writing colors:
+/// 
+/// ```
+/// use env_logger::{Builder, Env};
+/// 
+/// let env = Env::new().filter("MY_LOG").write_style("MY_LOG_STYLE");
+/// 
+/// env_logger::init_from_env(env);
+/// ```
 ///
 /// # Panics
 ///


### PR DESCRIPTION
Closes #45 and #42

# Some thoughts

- Do we want to treat new environment variables as breaking changes? Users overriding environment variables would probably want to know when new ones are added so they can be overridden too
- Should `Env` be an `&mut self` builder like the others?
- Should `Style` implement `Write` so you can call `writeln!(read_style, "{}", record.args())` to write an entire line using styles?

# Refactorings

I've moved all the terminal writing related code, like `Target` and the new `WriteStyle` into the `fmt` module to try and encapsulate it a bit better. Now we don't depend on `termcolor` directly in the `Logger` or `Builder`.

# Disabling colors

Adds a new builder property for whether or not to include colors. By default this is `RUST_LOG_STYLE`, but it can be overridden.

Setting this environment variable to `never` will disable colors and other styles:

```shell
$ export RUST_LOG_STYLE=never
$ ./my-app
```

Valid values are:

- `auto` (or missing/invalid) will decide whether or not the terminal supports colors
- `always` will always use colors
- `never` will never use colors

In order to support multiple environment variables, I've refactored our `from_env` functions to accept a generic `T: Into<Env>`, where `Env` is a container for the environment variables we care about. These methods can now be called in a few ways:

```rust
// reads filters from `MY_LOG` and styles from `RUST_LOG_STYLE`
env_logger::init_from_env("MY_LOG");

// reads filters from `MY_LOG` and styles from `MY_LOG_STYLE`
env_logger::init_from_env(Env::default().filter("MY_LOG").write_style("MY_LOG_STYLE"));
```

This lets us add new environment variables in the future without potentially breaking people. But it does mean if you're overriding all environment variables that new ones could slip in without you noticing.

# Using alternative environment variables

Since we use two environment variables to configure the logger we need an ergonomic way to pass different combinations of those variables to `from_env` methods. This PR adds an `Env` type with builder methods for naming environment variables:

```rust
env_logger::init_from_env(Env::new().filter("MY_LOG"));
```

With a few `From` conversions, the above is also equivalent to:

```rust
env_logger::init_from_env("MY_LOG");
```

Whether or not we want to keep these conversions is up for discussion.

# Writing colors

The color API has been refactored so it's a bit nicer to use in your own formats:

```rust
let mut style = buf.style();

style.set_color(Color::Red).set_bold(true).set_bg(Color::White);

writeln!(buf, "{}", style.value(42))
```

This saves you from having to split the writes into multiple calls and juggle `Result` types.

# Writing timestamps

Oh the `Formatter.timestamp` method is now also public so you can grab timestamps.