### PR TITLE
Dependencies: log: 0.4.0-rc.1 -> 0.4.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ categories = ["development-tools::debugging"]
 keywords = ["logging", "log", "logger"]
 
 [dependencies]
-log = { version = "0.4.0-rc.1", features = ["std"] }
+log = { version = "0.4.0", features = ["std"] }
 regex = { version = "0.2", optional = true }
 termcolor = "0.3"
 chrono = "0.4"


### PR DESCRIPTION
Tests run fine for me... so I assume we can update `log` to the `0.4.0` release, can't we?