### PR TITLE
Bump to 0.5.0-rc.2

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "env_logger"
-version = "0.5.0-rc.1" # remember to update html_root_url
+version = "0.5.0-rc.2" # remember to update html_root_url
 authors = ["The Rust Project Developers"]
 license = "MIT/Apache-2.0"
 readme = "README.md"

--- a/README.md
+++ b/README.md
@@ -17,8 +17,8 @@ It must be added along with `log` to the project dependencies:
 
 ```toml
 [dependencies]
-log = "0.4.0-rc.1"
-env_logger = "0.5.0-rc.1"
+log = "0.4.0"
+env_logger = "0.5.0-rc.2"
 ```
 
 `env_logger` must be initialized as early as possible in the project. After it's initialized, you can use the `log` macros to do actual logging.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -142,7 +142,7 @@
 
 #![doc(html_logo_url = "http://www.rust-lang.org/logos/rust-logo-128x128-blk-v2.png",
        html_favicon_url = "http://www.rust-lang.org/favicon.ico",
-       html_root_url = "https://docs.rs/env_logger/0.5.0-rc.1")]
+       html_root_url = "https://docs.rs/env_logger/0.5.0-rc.2")]
 #![cfg_attr(test, deny(warnings))]
 
 // When compiled for the rustc compiler itself we want to make sure that this is


### PR DESCRIPTION
This PR is just a version bump so we can put out another pre-release build. The rest of the issues in the `0.5.x` milestone can be done in a non-breaking way so if the community is happy with the API we've got then we can push out `0.5.0` proper :)