### PR TITLE
Allow building a Logger yourself

### DIFF
--- a/examples/direct_logger.rs
+++ b/examples/direct_logger.rs
@@ -1,0 +1,40 @@
+/*!
+Using `env_logger::Logger` and the `log::Log` trait directly.
+
+This example doesn't rely on environment variables, or having a static logger installed.
+*/
+
+extern crate log;
+extern crate env_logger;
+
+fn record() -> log::Record<'static> {
+    let error_metadata = log::MetadataBuilder::new()
+        .target("myApp")
+        .level(log::Level::Error)
+        .build();
+
+    log::Record::builder()
+        .metadata(error_metadata)
+        .args(format_args!("Error!"))
+        .line(Some(433))
+        .file(Some("app.rs"))
+        .module_path(Some("server"))
+        .build()
+}
+
+fn main() {
+    use log::Log;
+
+    let stylish_logger = env_logger::Builder::new()
+        .filter(None, log::LevelFilter::Error)
+        .write_style(env_logger::WriteStyle::Always)
+        .build();
+
+    let unstylish_logger = env_logger::Builder::new()
+        .filter(None, log::LevelFilter::Error)
+        .write_style(env_logger::WriteStyle::Never)
+        .build();
+    
+    stylish_logger.log(&record());
+    unstylish_logger.log(&record());
+}

--- a/src/fmt.rs
+++ b/src/fmt.rs
@@ -181,6 +181,12 @@ impl Default for WriteStyle {
 /// A terminal target with color awareness.
 pub(crate) struct Writer(BufferWriter);
 
+impl Writer {
+    pub(crate) fn write_style(&self) -> WriteStyle {
+        unimplemented!();
+    }
+}
+
 /// A builder for a terminal writer.
 /// 
 /// The target and style choice can be configured before building.
@@ -357,6 +363,10 @@ impl Formatter {
         Formatter {
             buf: Rc::new(RefCell::new(writer.0.buffer())),
         }
+    }
+
+    pub(crate) fn write_style(&self) -> WriteStyle {
+        unimplemented!();
     }
 
     /// Begin a new [`Style`].

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -473,8 +473,15 @@ impl Log for Logger {
             FORMATTER.with(|tl_buf| {
                 let mut tl_buf = tl_buf.borrow_mut();
 
-                if tl_buf.is_none() {
-                    *tl_buf = Some(Formatter::new(&self.writer));
+                // Check the buffer style. If it's different from the logger's 
+                // style then drop the buffer and recreate it.
+                match *tl_buf {
+                    Some(ref mut formatter) => {
+                        if formatter.write_style() != self.writer.write_style() {
+                            *formatter = Formatter::new(&self.writer)
+                        }
+                    },
+                    ref mut tl_buf => *tl_buf = Some(Formatter::new(&self.writer))
                 }
 
                 // The format is guaranteed to be `Some` by this point

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -426,7 +426,7 @@ impl Builder {
     /// This method is kept private because the only way we support building
     /// loggers is by installing them as the single global logger for the
     /// `log` crate.
-    fn build(&mut self) -> Logger {
+    pub fn build(&mut self) -> Logger {
         Logger {
             writer: self.writer.build(),
             filter: self.filter.build(),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,7 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-//! A simple logger configured via an environment variable which writes 
+//! A simple logger configured via environment variables which writes 
 //! to stdout or stderr, for use with the logging facade exposed by the
 //! [`log` crate][log-crate-url].
 //!
@@ -460,11 +460,9 @@ impl Log for Logger {
             // so will always at least have capacity for the largest log record formatted
             // on that thread.
             // 
-            // Because these buffers are tied to a particular logger, we don't let callers
-            // create instances of `Logger` themselves, or they'll race to configure the
-            // thread local buffer with their own configuration. This is still potentially
-            // an issue if a caller attempts to set and use the global logger multiple times,
-            // but in that case it's clearer that there's shared state at play.
+            // If multiple `Logger`s are used by the same threads then the thread-local
+            // formatter might have different color support. If this is the case the
+            // formatter and its buffer are discarded and recreated.
 
             thread_local! {
                 static FORMATTER: RefCell<Option<Formatter>> = RefCell::new(None);


### PR DESCRIPTION
Previously, I removed the ability to build and get a hold of a `Logger` type, because it relies on thread-local state that was configured using the style options of the first `Logger` to write a record.

This PR fixes up that situation so multiple `Logger`s can log on the same thread using the styles they were originally configured with. Each time we access the thread-local buffer we check to see if its configuration matches the current `Logger`. If it doesn't then we drop it and create a new one.