### PR TITLE
Prepare for 0.5.0 release

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "env_logger"
-version = "0.5.0-rc.2" # remember to update html_root_url
+version = "0.5.0" # remember to update html_root_url
 authors = ["The Rust Project Developers"]
 license = "MIT/Apache-2.0"
 readme = "README.md"

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ It must be added along with `log` to the project dependencies:
 ```toml
 [dependencies]
 log = "0.4.0"
-env_logger = "0.5.0-rc.2"
+env_logger = "0.5.0"
 ```
 
 `env_logger` must be initialized as early as possible in the project. After it's initialized, you can use the `log` macros to do actual logging.
@@ -54,7 +54,7 @@ Tests can use the `env_logger` crate to see log messages generated during that t
 log = "0.4.0"
 
 [dev-dependencies]
-env_logger = "0.5.0-rc.2"
+env_logger = "0.5.0"
 ```
 
 ```rust

--- a/src/fmt.rs
+++ b/src/fmt.rs
@@ -7,7 +7,7 @@
 //! 
 //! # Formatting log records
 //! 
-//! The format used to print log records can be customised using the [`Builder.format`]
+//! The format used to print log records can be customised using the [`Builder::format`]
 //! method.
 //! Custom formats can apply different color and weight to printed values using
 //! [`Style`] builders.
@@ -31,7 +31,7 @@
 //! 
 //! [`Formatter`]: struct.Formatter.html
 //! [`Style`]: struct.Style.html
-//! [`Builder.format`]: ../struct.Builder.html#method.format
+//! [`Builder::format`]: ../struct.Builder.html#method.format
 //! [`Write`]: https://doc.rust-lang.org/stable/std/io/trait.Write.html
 
 use std::io::prelude::*;
@@ -72,7 +72,7 @@ pub struct Formatter {
 
 /// A set of styles to apply to the terminal output.
 /// 
-/// Call [`Formatter.style`] to get a `Style` and use the builder methods to 
+/// Call [`Formatter::style`] to get a `Style` and use the builder methods to 
 /// set styling properties, like [color] and [weight].
 /// To print a value using the style, wrap it in a call to [`value`] when the log
 /// record is formatted.
@@ -118,9 +118,9 @@ pub struct Formatter {
 /// });
 /// ```
 /// 
-/// [`Formatter.style`]: struct.Formatter.html#method.style
-/// [color]: #method.color
-/// [weight]: #method.weight
+/// [`Formatter::style`]: struct.Formatter.html#method.style
+/// [color]: #method.set_color
+/// [weight]: #method.set_bold
 /// [`value`]: #method.value
 #[derive(Clone)]
 pub struct Style {
@@ -130,9 +130,9 @@ pub struct Style {
 
 /// A value that can be printed using the given styles.
 /// 
-/// It is the result of calling [`Style.value`].
+/// It is the result of calling [`Style::value`].
 /// 
-/// [`Style.value`]: struct.Style.html#method.value
+/// [`Style::value`]: struct.Style.html#method.value
 pub struct StyledValue<'a, T> {
     style: &'a Style,
     value: T,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -142,7 +142,7 @@
 
 #![doc(html_logo_url = "http://www.rust-lang.org/logos/rust-logo-128x128-blk-v2.png",
        html_favicon_url = "http://www.rust-lang.org/favicon.ico",
-       html_root_url = "https://docs.rs/env_logger/0.5.0-rc.2")]
+       html_root_url = "https://docs.rs/env_logger/0.5.0")]
 #![cfg_attr(test, deny(warnings))]
 
 // When compiled for the rustc compiler itself we want to make sure that this is
@@ -197,7 +197,7 @@ pub struct Env<'a> {
 /// default global logger.
 ///
 /// If you'd instead need access to the constructed `Logger`, you can use
-/// [`Logger::new()`] or the associated [`Builder`] and install it with the
+/// the associated [`Builder`] and install it with the
 /// [`log` crate][log-crate-url] directly.
 ///
 /// [log-crate-url]: https://docs.rs/log/
@@ -205,7 +205,6 @@ pub struct Env<'a> {
 /// [`try_init()`]: fn.try_init.html
 /// [`Builder::init()`]: struct.Builder.html#method.init
 /// [`Builder::try_init()`]: struct.Builder.html#method.try_init
-/// [`Logger::new()`]: #method.new
 /// [`Builder`]: struct.Builder.html
 pub struct Logger {
     writer: fmt::Writer,
@@ -347,7 +346,7 @@ impl Builder {
     /// to format and output without intermediate heap allocations. The default 
     /// `env_logger` formatter takes advantage of this.
     ///
-    /// [`Formatter`]: struct.Formatter.html
+    /// [`Formatter`]: fmt/struct.Formatter.html
     /// [`String`]: https://doc.rust-lang.org/stable/std/string/struct.String.html
     /// [`std::fmt`]: https://doc.rust-lang.org/std/fmt/index.html
     pub fn format<F: 'static>(&mut self, format: F) -> &mut Self


### PR DESCRIPTION
- Drops the `-rc`prerelease from the version number
- Fixes some broken links and inconsistencies in the docs