### PR TITLE
Avoid panicking for logging-while-logging

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,5 +23,9 @@ chrono = "0.4"
 name = "regexp_filter"
 harness = false
 
+[[test]]
+name = "log-in-log"
+harness = false
+
 [features]
 default = ["regex"]

--- a/tests/log-in-log.rs
+++ b/tests/log-in-log.rs
@@ -1,0 +1,38 @@
+#[macro_use] extern crate log;
+extern crate env_logger;
+
+use std::process;
+use std::fmt;
+use std::env;
+use std::str;
+
+struct Foo;
+
+impl fmt::Display for Foo {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        info!("test");
+        f.write_str("bar")
+    }
+}
+
+fn main() {
+    env_logger::init();
+    if env::var("YOU_ARE_TESTING_NOW").is_ok() {
+        return info!("{}", Foo);
+    }
+
+    let exe = env::current_exe().unwrap();
+    let out = process::Command::new(exe)
+        .env("YOU_ARE_TESTING_NOW", "1")
+        .env("RUST_LOG", "debug")
+        .output()
+        .unwrap_or_else(|e| panic!("Unable to start child process: {}", e));
+    if out.status.success() {
+        return
+    }
+
+    println!("test failed: {}", out.status);
+    println!("--- stdout\n{}", str::from_utf8(&out.stdout).unwrap());
+    println!("--- stderr\n{}", str::from_utf8(&out.stderr).unwrap());
+    process::exit(1);
+}


### PR DESCRIPTION
The `borrow_mut` panic could trip if a log happened while otherwise already
logging, so this adds a test and then avoid the panic in a relatively naive way.
If the panic should be avoided differently though, just let me know!