### PR TITLE
Added fmt::Style::set_intense

### DIFF
--- a/src/fmt.rs
+++ b/src/fmt.rs
@@ -318,6 +318,33 @@ impl Style {
         self
     }
 
+    /// Set the text intensity.
+    /// 
+    /// If `yes` is true then text will be written in a brighter color.
+    /// If `yes` is false then text will be written in the default color.
+    /// 
+    /// # Examples
+    /// 
+    /// Create a style with intense text:
+    /// 
+    /// ```
+    /// use std::io::Write;
+    /// 
+    /// let mut builder = env_logger::Builder::new();
+    /// 
+    /// builder.format(|buf, record| {
+    ///     let mut style = buf.style();
+    /// 
+    ///     style.set_intense(true);
+    /// 
+    ///     writeln!(buf, "{}", style.value(record.args()))
+    /// });
+    /// ```
+    pub fn set_intense(&mut self, yes: bool) -> &mut Style {
+        self.spec.set_intense(yes);
+        self
+    }
+
     /// Set the background color.
     /// 
     /// # Examples


### PR DESCRIPTION
It's a pretty much exact copy of `set_bold`. The wording might be too strong, though, because people's color schemes might make it so that the 'more intense' color is actually darker.

Closes #59.