### PR TITLE
ci: add minimum Rust version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 language: rust
 sudo: false
 rust:
+  - 1.18.0
   - stable
   - beta
   - nightly


### PR DESCRIPTION
This commit adds a specific version of Rust to test CI against.

Note that this PR isn't necessarily requesting any specific policy with respect to the minimum Rust version. Rather, this is a request for CI to be gated on a specific version of Rust so that the minimum version can be bumped consciously. This also serves as a useful documentation tool for perspective users. A glance at the CI configuration will yield important information about what version of the Rust compiler is required to build this crate.