### PR TITLE
Allow toggling parts of the default format

### DIFF
--- a/examples/custom_default_format.rs
+++ b/examples/custom_default_format.rs
@@ -25,7 +25,8 @@ use env_logger::{Env, Builder};
 
 fn init_logger() {
     let env = Env::default()
-        .filter("MY_LOG_LEVEL");
+        .filter("MY_LOG_LEVEL")
+        .write_style("MY_LOG_STYLE");
 
     let mut builder = Builder::from_env(env);
 

--- a/examples/custom_default_format.rs
+++ b/examples/custom_default_format.rs
@@ -1,0 +1,43 @@
+/*!
+Disabling parts of the default format.
+
+Before running this example, try setting the `MY_LOG_LEVEL` environment variable to `info`:
+
+```no_run,shell
+$ export MY_LOG_LEVEL='info'
+```
+
+Also try setting the `MY_LOG_STYLE` environment variable to `never` to disable colors
+or `auto` to enable them:
+
+```no_run,shell
+$ export MY_LOG_STYLE=never
+```
+
+If you want to control the logging output completely, see the `custom_logger` example.
+*/
+
+#[macro_use]
+extern crate log;
+extern crate env_logger;
+
+use env_logger::{Env, Builder};
+
+fn init_logger() {
+    let env = Env::default()
+        .filter("MY_LOG_LEVEL");
+
+    let mut builder = Builder::from_env(env);
+
+    builder
+        .default_format_level(false)
+        .default_format_timestamp(false);
+
+    builder.init();
+}
+
+fn main() {
+    init_logger();
+
+    info!("a log from `MyLogger`");
+}

--- a/examples/custom_logger.rs
+++ b/examples/custom_logger.rs
@@ -7,13 +7,6 @@ Before running this example, try setting the `MY_LOG_LEVEL` environment variable
 $ export MY_LOG_LEVEL='info'
 ```
 
-Also try setting the `MY_LOG_STYLE` environment variable to `never` to disable colors
-or `auto` to enable them:
-
-```no_run,shell
-$ export MY_LOG_STYLE=never
-```
-
 If you only want to change the way logs are formatted, look at the `custom_format` example.
 */
 

--- a/examples/default.rs
+++ b/examples/default.rs
@@ -19,8 +19,14 @@ $ export MY_LOG_STYLE=never
 extern crate log;
 extern crate env_logger;
 
+use env_logger::Env;
+
 fn main() {
-    env_logger::init_from_env("MY_LOG_LEVEL");
+    let env = Env::default()
+        .filter("MY_LOG_LEVEL")
+        .write_style("MY_LOG_STYLE");
+
+    env_logger::init_from_env(env);
 
     trace!("some trace log");
     debug!("some debug log");

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -356,6 +356,25 @@ impl Builder {
     /// Use the [`filter`] and [`write_style`] methods to configure the builder
     /// or use [`from_env`] or [`from_default_env`] instead.
     /// 
+    /// # Examples
+    /// 
+    /// Create a new builder and configure filters and style:
+    /// 
+    /// ```
+    /// # extern crate log;
+    /// # extern crate env_logger;
+    /// # fn main() {
+    /// use log::LevelFilter;
+    /// use env_logger::{Builder, WriteStyle};
+    /// 
+    /// let mut builder = Builder::new();
+    /// 
+    /// builder.filter(None, LevelFilter::Info)
+    ///        .write_style(WriteStyle::Always)
+    ///        .init();
+    /// # }
+    /// ```
+    /// 
     /// [`filter`]: #method.filter
     /// [`write_style`]: #method.write_style
     /// [`from_env`]: #method.from_env
@@ -433,17 +452,6 @@ impl Builder {
         Self::from_env(Env::default())
     }
 
-    /// Adds filters to the logger.
-    ///
-    /// The given module (if any) will log at most the specified level provided.
-    /// If no module is provided then the filter will apply to all log messages.
-    pub fn filter(&mut self,
-                  module: Option<&str>,
-                  level: LevelFilter) -> &mut Self {
-        self.filter.filter(module, level);
-        self
-    }
-
     /// Sets the format function for formatting the log output.
     ///
     /// This function is called on each record logged and should format the
@@ -453,6 +461,19 @@ impl Builder {
     /// `Formatter` so that implementations can use the [`std::fmt`] macros 
     /// to format and output without intermediate heap allocations. The default 
     /// `env_logger` formatter takes advantage of this.
+    /// 
+    /// # Examples
+    /// 
+    /// Use a custom format to write only the log message:
+    /// 
+    /// ```
+    /// use std::io::Write;
+    /// use env_logger::Builder;
+    /// 
+    /// let mut builder = Builder::new();
+    /// 
+    /// builder.format(|buf, record| write!(buf, "{}", record.args()));
+    /// ```
     ///
     /// [`Formatter`]: fmt/struct.Formatter.html
     /// [`String`]: https://doc.rust-lang.org/stable/std/string/struct.String.html
@@ -465,6 +486,8 @@ impl Builder {
     }
 
     /// Use the default format.
+    /// 
+    /// This method will clear any custom format set on the builder.
     pub fn default_format(&mut self) -> &mut Self {
         self.format.custom_format = None;
         self
@@ -488,20 +511,31 @@ impl Builder {
         self
     }
 
-    /// Sets the target for the log output.
+    /// Adds filters to the logger.
     ///
-    /// Env logger can log to either stdout or stderr. The default is stderr.
-    pub fn target(&mut self, target: fmt::Target) -> &mut Self {
-        self.writer.target(target);
-        self
-    }
-
-    /// Sets whether or not styles will be written.
+    /// The given module (if any) will log at most the specified level provided.
+    /// If no module is provided then the filter will apply to all log messages.
     /// 
-    /// This can be useful in environments that don't support control characters
-    /// for setting colors.
-    pub fn write_style(&mut self, write_style: fmt::WriteStyle) -> &mut Self {
-        self.writer.write_style(write_style);
+    /// # Examples
+    /// 
+    /// Only include messages for warning and above for logs in `path::to::module`:
+    /// 
+    /// ```
+    /// # extern crate log;
+    /// # extern crate env_logger;
+    /// # fn main() {
+    /// use log::LevelFilter;
+    /// use env_logger::Builder;
+    /// 
+    /// let mut builder = Builder::new();
+    /// 
+    /// builder.filter(Some("path::to::module"), LevelFilter::Info);
+    /// # }
+    /// ```
+    pub fn filter(&mut self,
+                  module: Option<&str>,
+                  level: LevelFilter) -> &mut Self {
+        self.filter.filter(module, level);
         self
     }
 
@@ -511,6 +545,47 @@ impl Builder {
     /// See the module documentation for more details.
     pub fn parse(&mut self, filters: &str) -> &mut Self {
         self.filter.parse(filters);
+        self
+    }
+
+    /// Sets the target for the log output.
+    ///
+    /// Env logger can log to either stdout or stderr. The default is stderr.
+    /// 
+    /// # Examples
+    /// 
+    /// Write log message to `stdout`:
+    /// 
+    /// ```
+    /// use env_logger::{Builder, Target};
+    /// 
+    /// let mut builder = Builder::new();
+    /// 
+    /// builder.target(Target::Stdout);
+    /// ```
+    pub fn target(&mut self, target: fmt::Target) -> &mut Self {
+        self.writer.target(target);
+        self
+    }
+
+    /// Sets whether or not styles will be written.
+    /// 
+    /// This can be useful in environments that don't support control characters
+    /// for setting colors.
+    /// 
+    /// # Examples
+    /// 
+    /// Never attempt to write styles:
+    /// 
+    /// ```
+    /// use env_logger::{Builder, WriteStyle};
+    /// 
+    /// let mut builder = Builder::new();
+    /// 
+    /// builder.write_style(WriteStyle::Never);
+    /// ```
+    pub fn write_style(&mut self, write_style: fmt::WriteStyle) -> &mut Self {
+        self.writer.write_style(write_style);
         self
     }
 


### PR DESCRIPTION
closes #48 

# `default_format` methods

This PR tweaks the default format a bit so we can conditionally enable/disable parts of it in the main `Builder`. The API looks like:

```rust
impl Builder {
    fn default_format(&mut self) -> &mut Self;
    fn default_format_timestamp(&mut self, write: bool) -> &mut Self;
    fn default_format_module_path(&mut self, write: bool) -> &mut Self;
    fn default_format_level(&mut self, write: bool) -> &mut Self;
}
```

This isn't the most elegant API, but I think it solves the problem of conveniently tweaking the default format without needing to import types or figure out the custom formatting API. We could bikeshed the naming (maybe `use_default_format` and `write_default_format_timestamp`?)

Calling `default_format_*` will store whether or not we want to include those parts of the log, without affecting a custom format. That means:

```rust
Builder::new()
    .format(|buf, record| { ... })
    .default_format_timestamp(false)
    .init();
```

Is the same as:

```rust
Builder::new()
    .format(|buf, record| { ... })
    .init();
```

Setting a custom format won't clobber any values passed to `default_format_*` methods. That means:

```rust
Builder::new()
    .default_format_timestamp(false)
    .format(|buf, record| { ... })
    .default_format()
    .init();
```

Is the same as:

```rust
Builder::new()
    .default_format_timestamp(false)
    .init();
```

I'm not expecting users to hop between custom and default formats, but I thought these were the least surprising semantics.

The docs need fleshing out.

# `from_default_env`

This PR also adds a new `from_default_env` method that's a convenient way of calling `from_env(env_logger::Env::default())`.