### PR TITLE
Use humantime instead of chrono

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ keywords = ["logging", "log", "logger"]
 log = { version = "0.4.0", features = ["std"] }
 regex = { version = "0.2", optional = true }
 termcolor = "0.3"
-chrono = "0.4"
+humantime = "1.1.0"
 atty = "0.2"
 
 [[test]]

--- a/src/fmt.rs
+++ b/src/fmt.rs
@@ -1,34 +1,34 @@
 //! Formatting for log records.
-//! 
+//!
 //! This module contains a [`Formatter`] that can be used to format log records
 //! into without needing temporary allocations. Usually you won't need to worry
 //! about the contents of this module and can use the `Formatter` like an ordinary
 //! [`Write`].
-//! 
+//!
 //! # Formatting log records
-//! 
+//!
 //! The format used to print log records can be customised using the [`Builder::format`]
 //! method.
 //! Custom formats can apply different color and weight to printed values using
 //! [`Style`] builders.
-//! 
+//!
 //! ```
 //! use std::io::Write;
 //! use env_logger::fmt::Color;
-//! 
+//!
 //! let mut builder = env_logger::Builder::new();
-//! 
+//!
 //! builder.format(|buf, record| {
 //!     let mut level_style = buf.style();
-//! 
+//!
 //!     level_style.set_color(Color::Red).set_bold(true);
-//! 
+//!
 //!     writeln!(buf, "{}: {}",
 //!         level_style.value(record.level()),
 //!         record.args())
 //! });
 //! ```
-//! 
+//!
 //! [`Formatter`]: struct.Formatter.html
 //! [`Style`]: struct.Style.html
 //! [`Builder::format`]: ../struct.Builder.html#method.format
@@ -38,31 +38,31 @@ use std::io::prelude::*;
 use std::{io, fmt};
 use std::rc::Rc;
 use std::cell::RefCell;
+use std::time::SystemTime;
 
 use termcolor::{ColorSpec, ColorChoice, Buffer, BufferWriter, WriteColor};
-use chrono::{DateTime, Utc};
-use chrono::format::Item;
 use atty;
+use humantime::format_rfc3339_seconds;
 
 pub use termcolor::Color;
 
 /// A formatter to write logs into.
-/// 
+///
 /// `Formatter` implements the standard [`Write`] trait for writing log records.
 /// It also supports terminal colors, through the [`style`] method.
-/// 
+///
 /// # Examples
-/// 
+///
 /// Use the [`writeln`] macro to easily format a log record:
-/// 
+///
 /// ```
 /// use std::io::Write;
-/// 
+///
 /// let mut builder = env_logger::Builder::new();
-/// 
+///
 /// builder.format(|buf, record| writeln!(buf, "{}: {}", record.level(), record.args()));
 /// ```
-/// 
+///
 /// [`Write`]: https://doc.rust-lang.org/stable/std/io/trait.Write.html
 /// [`writeln`]: https://doc.rust-lang.org/stable/std/macro.writeln.html
 /// [`style`]: #method.style
@@ -72,53 +72,53 @@ pub struct Formatter {
 }
 
 /// A set of styles to apply to the terminal output.
-/// 
-/// Call [`Formatter::style`] to get a `Style` and use the builder methods to 
+///
+/// Call [`Formatter::style`] to get a `Style` and use the builder methods to
 /// set styling properties, like [color] and [weight].
 /// To print a value using the style, wrap it in a call to [`value`] when the log
 /// record is formatted.
-/// 
+///
 /// # Examples
-/// 
+///
 /// Create a bold, red colored style and use it to print the log level:
-/// 
+///
 /// ```
 /// use std::io::Write;
 /// use env_logger::fmt::Color;
-/// 
+///
 /// let mut builder = env_logger::Builder::new();
-/// 
+///
 /// builder.format(|buf, record| {
 ///     let mut level_style = buf.style();
-/// 
+///
 ///     level_style.set_color(Color::Red).set_bold(true);
-/// 
+///
 ///     writeln!(buf, "{}: {}",
 ///         level_style.value(record.level()),
 ///         record.args())
 /// });
 /// ```
-/// 
+///
 /// Styles can be re-used to output multiple values:
-/// 
+///
 /// ```
 /// use std::io::Write;
 /// use env_logger::fmt::Color;
-/// 
+///
 /// let mut builder = env_logger::Builder::new();
-/// 
+///
 /// builder.format(|buf, record| {
 ///     let mut bold = buf.style();
-/// 
+///
 ///     bold.set_bold(true);
-/// 
+///
 ///     writeln!(buf, "{}: {} {}",
 ///         bold.value(record.level()),
 ///         bold.value("some bold text"),
 ///         record.args())
 /// });
 /// ```
-/// 
+///
 /// [`Formatter::style`]: struct.Formatter.html#method.style
 /// [color]: #method.set_color
 /// [weight]: #method.set_bold
@@ -130,9 +130,9 @@ pub struct Style {
 }
 
 /// A value that can be printed using the given styles.
-/// 
+///
 /// It is the result of calling [`Style::value`].
-/// 
+///
 /// [`Style::value`]: struct.Style.html#method.value
 pub struct StyledValue<'a, T> {
     style: &'a Style,
@@ -140,13 +140,13 @@ pub struct StyledValue<'a, T> {
 }
 
 /// An [RFC3339] formatted timestamp.
-/// 
+///
 /// The timestamp implements [`Display`] and can be written to a [`Formatter`].
-/// 
+///
 /// [RFC3339]: https://www.ietf.org/rfc/rfc3339.txt
 /// [`Display`]: https://doc.rust-lang.org/stable/std/fmt/trait.Display.html
 /// [`Formatter`]: struct.Formatter.html
-pub struct Timestamp(DateTime<Utc>);
+pub struct Timestamp(SystemTime);
 
 /// Log target, either `stdout` or `stderr`.
 #[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
@@ -193,7 +193,7 @@ impl Writer {
 }
 
 /// A builder for a terminal writer.
-/// 
+///
 /// The target and style choice can be configured before building.
 pub(crate) struct Builder {
     target: Target,
@@ -216,9 +216,9 @@ impl Builder {
     }
 
     /// Parses a style choice string.
-    /// 
+    ///
     /// See the [Disabling colors] section for more details.
-    /// 
+    ///
     /// [Disabling colors]: ../index.html#disabling-colors
     pub fn parse(&mut self, write_style: &str) -> &mut Self {
         self.write_style(parse_write_style(write_style))
@@ -267,22 +267,22 @@ impl Default for Builder {
 
 impl Style {
     /// Set the text color.
-    /// 
+    ///
     /// # Examples
-    /// 
+    ///
     /// Create a style with red text:
-    /// 
+    ///
     /// ```
     /// use std::io::Write;
     /// use env_logger::fmt::Color;
-    /// 
+    ///
     /// let mut builder = env_logger::Builder::new();
-    /// 
+    ///
     /// builder.format(|buf, record| {
     ///     let mut style = buf.style();
-    /// 
+    ///
     ///     style.set_color(Color::Red);
-    /// 
+    ///
     ///     writeln!(buf, "{}", style.value(record.args()))
     /// });
     /// ```
@@ -292,24 +292,24 @@ impl Style {
     }
 
     /// Set the text weight.
-    /// 
+    ///
     /// If `yes` is true then text will be written in bold.
     /// If `yes` is false then text will be written in the default weight.
-    /// 
+    ///
     /// # Examples
-    /// 
+    ///
     /// Create a style with bold text:
-    /// 
+    ///
     /// ```
     /// use std::io::Write;
-    /// 
+    ///
     /// let mut builder = env_logger::Builder::new();
-    /// 
+    ///
     /// builder.format(|buf, record| {
     ///     let mut style = buf.style();
-    /// 
+    ///
     ///     style.set_bold(true);
-    /// 
+    ///
     ///     writeln!(buf, "{}", style.value(record.args()))
     /// });
     /// ```
@@ -319,24 +319,24 @@ impl Style {
     }
 
     /// Set the text intensity.
-    /// 
+    ///
     /// If `yes` is true then text will be written in a brighter color.
     /// If `yes` is false then text will be written in the default color.
-    /// 
+    ///
     /// # Examples
-    /// 
+    ///
     /// Create a style with intense text:
-    /// 
+    ///
     /// ```
     /// use std::io::Write;
-    /// 
+    ///
     /// let mut builder = env_logger::Builder::new();
-    /// 
+    ///
     /// builder.format(|buf, record| {
     ///     let mut style = buf.style();
-    /// 
+    ///
     ///     style.set_intense(true);
-    /// 
+    ///
     ///     writeln!(buf, "{}", style.value(record.args()))
     /// });
     /// ```
@@ -346,22 +346,22 @@ impl Style {
     }
 
     /// Set the background color.
-    /// 
+    ///
     /// # Examples
-    /// 
+    ///
     /// Create a style with a yellow background:
-    /// 
+    ///
     /// ```
     /// use std::io::Write;
     /// use env_logger::fmt::Color;
-    /// 
+    ///
     /// let mut builder = env_logger::Builder::new();
-    /// 
+    ///
     /// builder.format(|buf, record| {
     ///     let mut style = buf.style();
-    /// 
+    ///
     ///     style.set_bg(Color::Yellow);
-    /// 
+    ///
     ///     writeln!(buf, "{}", style.value(record.args()))
     /// });
     /// ```
@@ -371,24 +371,24 @@ impl Style {
     }
 
     /// Wrap a value in the style.
-    /// 
+    ///
     /// The same `Style` can be used to print multiple different values.
-    /// 
+    ///
     /// # Examples
-    /// 
+    ///
     /// Create a bold, red colored style and use it to print the log level:
-    /// 
+    ///
     /// ```
     /// use std::io::Write;
     /// use env_logger::fmt::Color;
-    /// 
+    ///
     /// let mut builder = env_logger::Builder::new();
-    /// 
+    ///
     /// builder.format(|buf, record| {
     ///     let mut style = buf.style();
-    /// 
+    ///
     ///     style.set_color(Color::Red).set_bold(true);
-    /// 
+    ///
     ///     writeln!(buf, "{}: {}",
     ///         style.value(record.level()),
     ///         record.args())
@@ -415,28 +415,28 @@ impl Formatter {
     }
 
     /// Begin a new [`Style`].
-    /// 
+    ///
     /// # Examples
-    /// 
+    ///
     /// Create a bold, red colored style and use it to print the log level:
-    /// 
+    ///
     /// ```
     /// use std::io::Write;
     /// use env_logger::fmt::Color;
-    /// 
+    ///
     /// let mut builder = env_logger::Builder::new();
-    /// 
+    ///
     /// builder.format(|buf, record| {
     ///     let mut level_style = buf.style();
-    /// 
+    ///
     ///     level_style.set_color(Color::Red).set_bold(true);
-    /// 
+    ///
     ///     writeln!(buf, "{}: {}",
     ///         level_style.value(record.level()),
     ///         record.args())
     /// });
     /// ```
-    /// 
+    ///
     /// [`Style`]: struct.Style.html
     pub fn style(&self) -> Style {
         Style {
@@ -446,26 +446,26 @@ impl Formatter {
     }
 
     /// Get a [`Timestamp`] for the current date and time in UTC.
-    /// 
+    ///
     /// # Examples
-    /// 
+    ///
     /// Include the current timestamp with the log record:
-    /// 
+    ///
     /// ```
     /// use std::io::Write;
-    /// 
+    ///
     /// let mut builder = env_logger::Builder::new();
-    /// 
+    ///
     /// builder.format(|buf, record| {
     ///     let ts = buf.timestamp();
-    /// 
+    ///
     ///     writeln!(buf, "{}: {}: {}", ts, record.level(), record.args())
     /// });
     /// ```
-    /// 
+    ///
     /// [`Timestamp`]: struct.Timestamp.html
     pub fn timestamp(&self) -> Timestamp {
-        Timestamp(Utc::now())
+        Timestamp(SystemTime::now())
     }
 
     pub(crate) fn print(&self, writer: &Writer) -> io::Result<()> {
@@ -571,29 +571,7 @@ impl_styled_value_fmt!(
 
 impl fmt::Display for Timestamp {
     fn fmt(&self, f: &mut fmt::Formatter)->fmt::Result {
-        const ITEMS: &'static [Item<'static>] = {
-            use chrono::format::Item::*;
-            use chrono::format::Numeric::*;
-            use chrono::format::Fixed::*;
-            use chrono::format::Pad::*;
-
-            &[
-                Numeric(Year, Zero),
-                Literal("-"),
-                Numeric(Month, Zero),
-                Literal("-"),
-                Numeric(Day, Zero),
-                Literal("T"),
-                Numeric(Hour, Zero),
-                Literal(":"),
-                Numeric(Minute, Zero),
-                Literal(":"),
-                Numeric(Second, Zero),
-                Fixed(TimezoneOffsetZ),
-            ]
-        };
-
-        self.0.format_with_items(ITEMS.iter().cloned()).fmt(f)
+        format_rfc3339_seconds(self.0).fmt(f)
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,7 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-//! A simple logger configured via environment variables which writes 
+//! A simple logger configured via environment variables which writes
 //! to stdout or stderr, for use with the logging facade exposed by the
 //! [`log` crate][log-crate-url].
 //!
@@ -126,18 +126,18 @@
 //! * `error,hello=warn/[0-9]scopes` turn on global error logging and also
 //!   warn for hello. In both cases the log message must include a single digit
 //!   number followed by 'scopes'.
-//! 
+//!
 //! ## Disabling colors
-//! 
+//!
 //! Colors and other styles can be configured with the `RUST_LOG_STYLE`
 //! environment variable. It accepts the following values:
-//! 
+//!
 //! * `auto` (default) will attempt to print style characters, but don't force the issue.
 //! If the console isn't available on Windows, or if TERM=dumb, for example, then don't print colors.
 //! * `always` will always print style characters even if they aren't supported by the terminal.
 //! This includes emitting ANSI colors on Windows if the console API is unavailable.
 //! * `never` will never print style characters.
-//! 
+//!
 //! [log-crate-url]: https://docs.rs/log/
 
 #![doc(html_logo_url = "http://www.rust-lang.org/logos/rust-logo-128x128-blk-v2.png",
@@ -154,7 +154,7 @@
 
 extern crate log;
 extern crate termcolor;
-extern crate chrono;
+extern crate humantime;
 extern crate atty;
 
 use std::env;
@@ -175,12 +175,12 @@ const DEFAULT_FILTER_ENV: &'static str = "RUST_LOG";
 const DEFAULT_WRITE_STYLE_ENV: &'static str = "RUST_LOG_STYLE";
 
 /// Set of environment variables to configure from.
-/// 
+///
 /// By default, the `Env` will read the following environment variables:
-/// 
+///
 /// - `RUST_LOG`: the level filter
 /// - `RUST_LOG_STYLE`: whether or not to print styles with records.
-/// 
+///
 /// These sources can be configured using the builder methods on `Env`.
 #[derive(Debug)]
 pub struct Env<'a> {
@@ -232,7 +232,7 @@ pub struct Logger {
 ///
 /// fn main() {
 ///     let mut builder = Builder::new();
-/// 
+///
 ///     builder.format(|buf, record| writeln!(buf, "{} - {}", record.level(), record.args()))
 ///            .filter(None, LevelFilter::Info);
 ///
@@ -282,29 +282,29 @@ impl Builder {
     }
 
     /// Initializes the log builder from the environment.
-    /// 
+    ///
     /// The variables used to read configuration from can be tweaked before
     /// passing in.
-    /// 
+    ///
     /// # Examples
-    /// 
+    ///
     /// Initialise a logger using the default environment variables:
-    /// 
+    ///
     /// ```
     /// use env_logger::{Builder, Env};
-    /// 
+    ///
     /// let mut builder = Builder::from_env(Env::default());
     /// builder.init();
     /// ```
-    /// 
+    ///
     /// Initialise a logger using the `MY_LOG` variable for filtering and
     /// `MY_LOG_STYLE` for whether or not to write styles:
-    /// 
+    ///
     /// ```
     /// use env_logger::{Builder, Env};
-    /// 
+    ///
     /// let env = Env::new().filter("MY_LOG").write_style("MY_LOG_STYLE");
-    /// 
+    ///
     /// let mut builder = Builder::from_env(env);
     /// builder.init();
     /// ```
@@ -343,8 +343,8 @@ impl Builder {
     /// log record and output it to the given [`Formatter`].
     ///
     /// The format function is expected to output the string directly to the
-    /// `Formatter` so that implementations can use the [`std::fmt`] macros 
-    /// to format and output without intermediate heap allocations. The default 
+    /// `Formatter` so that implementations can use the [`std::fmt`] macros
+    /// to format and output without intermediate heap allocations. The default
     /// `env_logger` formatter takes advantage of this.
     ///
     /// [`Formatter`]: fmt/struct.Formatter.html
@@ -366,7 +366,7 @@ impl Builder {
     }
 
     /// Sets whether or not styles will be written.
-    /// 
+    ///
     /// This can be useful in environments that don't support control characters
     /// for setting colors.
     pub fn write_style(&mut self, write_style: fmt::WriteStyle) -> &mut Self {
@@ -385,7 +385,7 @@ impl Builder {
 
     /// Parses whether or not to write styles in the same form as the `RUST_LOG_STYLE`
     /// environment variable.
-    /// 
+    ///
     /// See the module documentation for more details.
     pub fn parse_write_style(&mut self, write_style: &str) -> &mut Self {
         self.writer.parse(write_style);
@@ -422,7 +422,7 @@ impl Builder {
     }
 
     /// Build an env logger.
-    /// 
+    ///
     /// This method is kept private because the only way we support building
     /// loggers is by installing them as the single global logger for the
     /// `log` crate.
@@ -459,7 +459,7 @@ impl Log for Logger {
             // to the terminal. We clear these buffers afterwards, but they aren't shrinked
             // so will always at least have capacity for the largest log record formatted
             // on that thread.
-            // 
+            //
             // If multiple `Logger`s are used by the same threads then the thread-local
             // formatter might have different color support. If this is the case the
             // formatter and its buffer are discarded and recreated.
@@ -483,7 +483,7 @@ impl Log for Logger {
                     Err(_) => &mut b,
                 };
 
-                // Check the buffer style. If it's different from the logger's 
+                // Check the buffer style. If it's different from the logger's
                 // style then drop the buffer and recreate it.
                 match *tl_buf {
                     Some(ref mut formatter) => {
@@ -612,21 +612,21 @@ pub fn init() {
 ///
 /// This should be called early in the execution of a Rust program. Any log
 /// events that occur before initialization will be ignored.
-/// 
+///
 /// # Examples
-/// 
+///
 /// Initialise a logger using the `MY_LOG` environment variable for filters
 /// and `MY_LOG_STYLE` for writing colors:
-/// 
+///
 /// ```
 /// # extern crate env_logger;
 /// use env_logger::{Builder, Env};
-/// 
+///
 /// # fn run() -> Result<(), Box<::std::error::Error>> {
 /// let env = Env::new().filter("MY_LOG").write_style("MY_LOG_STYLE");
-/// 
+///
 /// env_logger::try_init_from_env(env)?;
-/// 
+///
 /// Ok(())
 /// # }
 /// # fn main() { run().unwrap(); }
@@ -650,17 +650,17 @@ where
 ///
 /// This should be called early in the execution of a Rust program. Any log
 /// events that occur before initialization will be ignored.
-/// 
+///
 /// # Examples
-/// 
+///
 /// Initialise a logger using the `MY_LOG` environment variable for filters
 /// and `MY_LOG_STYLE` for writing colors:
-/// 
+///
 /// ```
 /// use env_logger::{Builder, Env};
-/// 
+///
 /// let env = Env::new().filter("MY_LOG").write_style("MY_LOG_STYLE");
-/// 
+///
 /// env_logger::init_from_env(env);
 /// ```
 ///


### PR DESCRIPTION
I've just added rfc3339 timestamp support in humantime. And I find it's good match for env_logger.

Performance difference (just time formatting not logger):
```
     Running target/release/deps/datetime_format-7e6d1b8a3104a052

running 2 tests
test rfc3339_chrono            ... bench:         730 ns/iter (+/- 21)
test rfc3339_humantime_seconds ... bench:          73 ns/iter (+/- 3)
```
This uses same definition of chrono formatter as in env_logger.

Binary size difference:
```
- 0.2%   1.6%  10.5KiB chrono
- 0.0%   0.0%     305B time
+ 0.0%   0.3%   1.7KiB humantime
```
Measured using cargo-bloat on `examples/default.rs`

Dependencies difference:
```
 ├── atty v0.2.6
 │   [dependencies]
 │   └── libc v0.2.36
-├── chrono v0.4.0
+├── humantime v1.1.0-beta.3
 │   [dependencies]
-│   ├── num v0.1.42
-│   │   [dependencies]
-│   │   ├── num-integer v0.1.36
-│   │   │   [dependencies]
-│   │   │   └── num-traits v0.2.0
-│   │   ├── num-iter v0.1.35
-│   │   │   [dependencies]
-│   │   │   ├── num-integer v0.1.36 (*)
-│   │   │   └── num-traits v0.2.0 (*)
-│   │   └── num-traits v0.2.0 (*)
-│   └── time v0.1.39
-│       [dependencies]
-│       └── libc v0.2.36 (*)
-│       [dev-dependencies]
-│       └── winapi v0.3.4
+│   └── quick-error v1.2.1
 ├── log v0.4.1
 │   [dependencies]
 │   └── cfg-if v0.1.2

```
Reported by `cargo tree`

None of that is actually a life-saver. But there is [at least one crate](https://github.com/BurntSushi/ripgrep/pull/772/commits/e633d5062f662268fad1dd5d3c86e2060a6984e1) that avoids using env_logger specifically because it depends on quite large dependency tree of chrono.

So idea is to make `humantime` the time parser/formatter specifically for situations where chrono is an overkill. Humantime only depends on quick-error for error boilerplate and works with stdlib's SystemTime and Duration.

What do you think? 