### PR TITLE
Better error message when init called twice

### DIFF
--- a/examples/init_twice.rs
+++ b/examples/init_twice.rs
@@ -1,0 +1,13 @@
+/*!
+Call env_logger::init twice to demonstrate error.
+*/
+
+extern crate env_logger;
+
+fn main() {
+    println!("calling init first time");
+    env_logger::init();
+    println!("calling init second time");
+    env_logger::init();
+    unreachable!();
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -604,7 +604,7 @@ pub fn try_init() -> Result<(), SetLoggerError> {
 /// This function will panic if it is called more than once, or if another
 /// library has already initialized a global logger.
 pub fn init() {
-    try_init().unwrap();
+    try_init().expect("env_logger::init should not be called after logger initialized");
 }
 
 /// Attempts to initialize the global logger with an env logger from the given


### PR DESCRIPTION
Before this patch program outputs:

```
calling init first time
calling init second time
thread 'main' panicked at 'called `Result::unwrap()` on an `Err` value: SetLoggerError(())', libcore/result.rs:945:5
```

With this patch applied:

```
calling init first time
calling init second time
thread 'main' panicked at 'env_logger::init should not be called after logger initialized: SetLoggerError(())', libcore/result.rs:945:5
```