### PR TITLE
Add support for default env values

### DIFF
--- a/examples/default.rs
+++ b/examples/default.rs
@@ -23,8 +23,8 @@ use env_logger::Env;
 
 fn main() {
     let env = Env::default()
-        .filter("MY_LOG_LEVEL")
-        .write_style("MY_LOG_STYLE");
+        .filter_or("MY_LOG_LEVEL", "trace")
+        .write_style_or("MY_LOG_STYLE", "always");
 
     env_logger::init_from_env(env);
 

--- a/src/fmt.rs
+++ b/src/fmt.rs
@@ -709,7 +709,7 @@ impl FromStr for Color {
 
     fn from_str(s: &str) -> Result<Color, ParseColorError> {
         let tc = termcolor::Color::from_str(s).map_err(ParseColorError::termcolor)?;
-        Color::from_termcolor(tc).ok_or(ParseColorError::unrecognized(s.to_owned()))
+        Color::from_termcolor(tc).ok_or_else(|| ParseColorError::unrecognized(s.to_owned()))
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -211,8 +211,11 @@ pub mod fmt;
 
 pub use self::fmt::{Target, WriteStyle, Color, Formatter};
 
-const DEFAULT_FILTER_ENV: &'static str = "RUST_LOG";
-const DEFAULT_WRITE_STYLE_ENV: &'static str = "RUST_LOG_STYLE";
+/// The default name for the environment variable to read filters from.
+pub const DEFAULT_FILTER_ENV: &'static str = "RUST_LOG";
+
+/// The default name for the environment variable to read style preferences from.
+pub const DEFAULT_WRITE_STYLE_ENV: &'static str = "RUST_LOG_STYLE";
 
 /// Set of environment variables to configure from.
 ///


### PR DESCRIPTION
Closes #47 

# Default Values for Environment Variables

Adds 2 new methods to `Env` that can be used to supply a default value for environment variables if they're not set:

```rust
fn filter_or(name: impl Into<Cow<'a, str>>, default: impl Into<Cow<'a, str>>);
fn write_style_or(name: impl Into<Cow<'a, str>>, default: impl Into<Cow<'a, str>>);
```

The default value is a string with the same format as the values accepted by the environment variables. I thought this offered some simple symmetry between values from the environment and the defaults, even though it's not so type safe.

As an example, we can default the level to `info` if `MY_LOG_LEVEL` isn't set:

```rust
let env = Env::default()
    .filter_or("MY_LOG_LEVEL", "info")
    .write_style("MY_LOG_STYLE");

env_logger::init_from_env(env);
```

This also means you need to specify the name of the environment variable you want to use, but we could export constants for the default ones if folks don't want to write `RUST_LOG` manually.