### PR TITLE
Add methods for filtering by module and level

### DIFF
--- a/src/filter/mod.rs
+++ b/src/filter/mod.rs
@@ -197,6 +197,16 @@ impl Builder {
         builder
     }
 
+    /// Adds a directive to the filter for a specific module.
+    pub fn filter_module(&mut self, module: &str, level: LevelFilter) -> &mut Self {
+        self.filter(Some(module), level)
+    }
+
+    /// Adds a directive to the filter for all modules.
+    pub fn filter_level(&mut self, level: LevelFilter) -> &mut Self {
+        self.filter(None, level)
+    }
+
     /// Adds a directive to the filter.
     ///
     /// The given module (if any) will log at most the specified level provided.
@@ -206,7 +216,7 @@ impl Builder {
                   level: LevelFilter) -> &mut Self {
         self.directives.push(Directive {
             name: module.map(|s| s.to_string()),
-            level: level,
+            level,
         });
         self
     }

--- a/src/fmt.rs
+++ b/src/fmt.rs
@@ -287,7 +287,7 @@ impl Style {
     /// });
     /// ```
     pub fn set_color(&mut self, color: Color) -> &mut Style {
-        self.spec.set_fg(color.to_termcolor());
+        self.spec.set_fg(color.into_termcolor());
         self
     }
 
@@ -366,7 +366,7 @@ impl Style {
     /// });
     /// ```
     pub fn set_bg(&mut self, color: Color) -> &mut Style {
-        self.spec.set_bg(color.to_termcolor());
+        self.spec.set_bg(color.into_termcolor());
         self
     }
 
@@ -671,7 +671,7 @@ impl fmt::Display for ParseColorError {
 }
 
 impl Color {
-    fn to_termcolor(self) -> Option<termcolor::Color> {
+    fn into_termcolor(self) -> Option<termcolor::Color> {
         match self {
             Color::Black => Some(termcolor::Color::Black),
             Color::Blue => Some(termcolor::Color::Blue),
@@ -709,7 +709,7 @@ impl FromStr for Color {
 
     fn from_str(s: &str) -> Result<Color, ParseColorError> {
         let tc = termcolor::Color::from_str(s).map_err(ParseColorError::termcolor)?;
-        Color::from_termcolor(tc).ok_or_else(|| ParseColorError::unrecognized(s.to_owned()))
+        Color::from_termcolor(tc).ok_or_else(|| ParseColorError::unrecognized(s.into()))
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -529,6 +529,52 @@ impl Builder {
         self
     }
 
+    /// Adds a directive to the filter for a specific module.
+    ///
+    /// # Examples
+    ///
+    /// Only include messages for warning and above for logs in `path::to::module`:
+    ///
+    /// ```
+    /// # extern crate log;
+    /// # extern crate env_logger;
+    /// # fn main() {
+    /// use log::LevelFilter;
+    /// use env_logger::Builder;
+    ///
+    /// let mut builder = Builder::new();
+    ///
+    /// builder.filter_module("path::to::module", LevelFilter::Info);
+    /// # }
+    /// ```
+    pub fn filter_module(&mut self, module: &str, level: LevelFilter) -> &mut Self {
+        self.filter.filter_module(module, level);
+        self
+    }
+
+    /// Adds a directive to the filter for all modules.
+    ///
+    /// # Examples
+    ///
+    /// Only include messages for warning and above for logs in `path::to::module`:
+    ///
+    /// ```
+    /// # extern crate log;
+    /// # extern crate env_logger;
+    /// # fn main() {
+    /// use log::LevelFilter;
+    /// use env_logger::Builder;
+    ///
+    /// let mut builder = Builder::new();
+    ///
+    /// builder.filter_level(LevelFilter::Info);
+    /// # }
+    /// ```
+    pub fn filter_level(&mut self, level: LevelFilter) -> &mut Self {
+        self.filter.filter_level(level);
+        self
+    }
+
     /// Adds filters to the logger.
     ///
     /// The given module (if any) will log at most the specified level provided.


### PR DESCRIPTION
Closes #13 

# `filter_module` and `filter_level`

This PR adds two new methods to `Builder` and `filter::Builder` that are specific cases of the existing `filter` method:

- `filter_module` adds a directive for the given module. It's the same as `filter(Some(module), level)`
- `filter_level` adds a directive for all modules. It's the same as `filter(None, level)`