### PR TITLE
Bump min rustc to 1.20.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: rust
 sudo: false
 rust:
-  - 1.18.0
+  - 1.20.0
   - stable
   - beta
   - nightly

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,10 +17,10 @@ keywords = ["logging", "log", "logger"]
 status = "actively-developed"
 
 [dependencies]
-log = { version = "0.4.0", features = ["std"] }
-regex = { version = "1.0", optional = true }
+log = { version = "0.4", features = ["std"] }
+regex = { version = "1", optional = true }
 termcolor = "1"
-humantime = "1.1.0"
+humantime = "1.1"
 atty = "0.2"
 
 [[test]]


### PR DESCRIPTION
Our minimum `rustc` version for new builds without a lockfile have already been requiring `1.20.0`, this PR just updates our travis build to use the new minimum.