### PR TITLE
Add precise timestamp with nanos

### DIFF
--- a/src/fmt.rs
+++ b/src/fmt.rs
@@ -44,7 +44,7 @@ use std::time::SystemTime;
 
 use termcolor::{self, ColorSpec, ColorChoice, Buffer, BufferWriter, WriteColor};
 use atty;
-use humantime::format_rfc3339_seconds;
+use humantime::{format_rfc3339_seconds, format_rfc3339_nanos};
 
 /// A formatter to write logs into.
 ///
@@ -147,6 +147,10 @@ pub struct StyledValue<'a, T> {
 /// [`Display`]: https://doc.rust-lang.org/stable/std/fmt/trait.Display.html
 /// [`Formatter`]: struct.Formatter.html
 pub struct Timestamp(SystemTime);
+
+/// An [RFC3339] formatted timestamp with nanos
+#[derive(Debug)]
+pub struct PreciseTimestamp(SystemTime);
 
 /// Log target, either `stdout` or `stderr`.
 #[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
@@ -468,6 +472,11 @@ impl Formatter {
         Timestamp(SystemTime::now())
     }
 
+     /// Get a [`PreciseTimestamp`] for the current date and time in UTC with nanos.
+    pub fn precise_timestamp(&self) -> PreciseTimestamp {
+        PreciseTimestamp(SystemTime::now())
+    }
+
     pub(crate) fn print(&self, writer: &Writer) -> io::Result<()> {
         writer.inner.print(&self.buf.borrow())
     }
@@ -572,6 +581,12 @@ impl_styled_value_fmt!(
 impl fmt::Display for Timestamp {
     fn fmt(&self, f: &mut fmt::Formatter)->fmt::Result {
         format_rfc3339_seconds(self.0).fmt(f)
+    }
+}
+
+impl fmt::Display for PreciseTimestamp {
+    fn fmt(&self, f: &mut fmt::Formatter)->fmt::Result {
+        format_rfc3339_nanos(self.0).fmt(f)
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -268,6 +268,7 @@ struct Format {
     default_format_timestamp: bool,
     default_format_module_path: bool,
     default_format_level: bool,
+    default_format_timestamp_nanos: bool,
     custom_format: Option<Box<Fn(&mut Formatter, &Record) -> io::Result<()> + Sync + Send>>,
 }
 
@@ -277,6 +278,7 @@ impl Default for Format {
             default_format_timestamp: true,
             default_format_module_path: true,
             default_format_level: true,
+            default_format_timestamp_nanos: false,
             custom_format: None,
         }
     }
@@ -312,8 +314,13 @@ impl Format {
                 };
 
                 let write_ts = if self.default_format_timestamp {
-                    let ts = buf.timestamp();
-                    write!(buf, "{}: ", ts)
+                    if self.default_format_timestamp_nanos {
+                      let ts_nanos = buf.precise_timestamp();
+                      write!(buf, "{}: ", ts_nanos) 
+                    } else {
+                      let ts = buf.timestamp();
+                      write!(buf, "{}: ", ts)      
+                    }
                 } else {
                     Ok(())
                 };
@@ -526,6 +533,12 @@ impl Builder {
     /// Whether or not to write the timestamp in the default format.
     pub fn default_format_timestamp(&mut self, write: bool) -> &mut Self {
         self.format.default_format_timestamp = write;
+        self
+    }
+
+    /// Whether or not to write the timestamp with nanos.
+    pub fn default_format_timestamp_nanos(&mut self, write: bool) -> &mut Self {
+        self.format.default_format_timestamp_nanos = write;
         self
     }
 


### PR DESCRIPTION
You have to use the following function to enable timestamp with nanos:
`builder.default_format_timestamp_nanos(true);`
Example of output:
`2018-07-23T12:16:12.201528000Z`

Check #87 for details.