### PR TITLE
Use precise timestamps in custom format example

### DIFF
--- a/examples/custom_default_format.rs
+++ b/examples/custom_default_format.rs
@@ -32,7 +32,7 @@ fn init_logger() {
 
     builder
         .default_format_level(false)
-        .default_format_timestamp(false);
+        .default_format_timestamp_nanos(true);
 
     builder.init();
 }


### PR DESCRIPTION
Just a simple tweak to the custom default format example to use the new `default_format_timestamp_nanos` method.