### PR TITLE
Make all dependencies optional

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,10 +8,7 @@ rust:
 before_script:
   - pip install 'travis-cargo<0.2' --user && export PATH=$HOME/.local/bin:$PATH
 script:
-  - cargo build --verbose
-  - cargo build --verbose --no-default-features
-  - cargo test --verbose
-  - cargo test --verbose --no-default-features
+  - cargo run -p ci
 after_success:
   - travis-cargo --only nightly doc-upload
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,7 @@ members = [
 [dependencies]
 log = { version = "0.4", features = ["std"] }
 regex = { version = "1.0.3", optional = true }
-termcolor = { version = "1.1", optional = true }
+termcolor = { version = "1.0.2", optional = true }
 humantime = { version = "1.1", optional = true }
 atty = { version = "0.2.5", optional = true }
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,11 @@ keywords = ["logging", "log", "logger"]
 [maintenance]
 status = "actively-developed"
 
+[workspace]
+members = [
+    "ci"
+]
+
 [dependencies]
 log = { version = "0.4", features = ["std"] }
 regex = { version = "1", optional = true }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,9 +19,9 @@ status = "actively-developed"
 [dependencies]
 log = { version = "0.4", features = ["std"] }
 regex = { version = "1", optional = true }
-termcolor = "1"
-humantime = "1.1"
-atty = "0.2"
+termcolor = { version = "1", optional = true }
+humantime = { version = "1.1", optional = true }
+atty = { version = "0.2", optional = true }
 
 [[test]]
 name = "regexp_filter"
@@ -32,4 +32,4 @@ name = "log-in-log"
 harness = false
 
 [features]
-default = ["regex"]
+default = ["termcolor", "atty", "humantime", "regex"]

--- a/ci/Cargo.toml
+++ b/ci/Cargo.toml
@@ -1,0 +1,7 @@
+[package]
+name = "ci"
+version = "0.0.0"
+authors = ["The Rust Project Developers"]
+publish = false
+
+[dependencies]

--- a/ci/src/main.rs
+++ b/ci/src/main.rs
@@ -1,0 +1,26 @@
+mod task;
+mod permute;
+
+use self::task::{test, TestArgs};
+use self::permute::permute;
+
+fn main() {
+    let features = [
+        "termcolor",
+        "humantime",
+        "atty",
+        "regex",
+    ];
+
+    // Run a default build
+    test(Default::default());
+
+    // Run a set of permutations
+    for features in permute(&features) {
+        test(TestArgs {
+            features,
+            default_features: false,
+            lib_only: true,
+        });
+    }
+}

--- a/ci/src/main.rs
+++ b/ci/src/main.rs
@@ -1,9 +1,6 @@
 mod task;
 mod permute;
 
-use self::task::{test, TestArgs};
-use self::permute::permute;
-
 fn main() {
     let features = [
         "termcolor",
@@ -13,11 +10,11 @@ fn main() {
     ];
 
     // Run a default build
-    test(Default::default());
+    task::test(Default::default());
 
     // Run a set of permutations
-    for features in permute(&features) {
-        test(TestArgs {
+    for features in permute::all(&features) {
+        task::test(task::TestArgs {
             features,
             default_features: false,
             lib_only: true,

--- a/ci/src/main.rs
+++ b/ci/src/main.rs
@@ -10,14 +10,28 @@ fn main() {
     ];
 
     // Run a default build
-    task::test(Default::default());
+    if !task::test(Default::default()) {
+        panic!("default test execution failed");
+    }
 
     // Run a set of permutations
-    for features in permute::all(&features) {
-        task::test(task::TestArgs {
-            features,
-            default_features: false,
-            lib_only: true,
-        });
+    let failed = permute::all(&features)
+        .into_iter()
+        .filter(|features| 
+            !task::test(task::TestArgs {
+                features: features.clone(),
+                default_features: false,
+                lib_only: true,
+            }))
+        .collect::<Vec<_>>();
+
+    if failed.len() > 0 {
+        for failed in failed {
+            eprintln!("FAIL: {:?}", failed);
+        }
+
+        panic!("test execution failed");
+    } else {
+        println!("test execution succeeded");
     }
 }

--- a/ci/src/permute.rs
+++ b/ci/src/permute.rs
@@ -1,6 +1,6 @@
 use std::collections::BTreeSet;
 
-pub fn permute<T>(input: &[T]) -> BTreeSet<BTreeSet<T>> where T: Ord + Eq + Clone {
+pub fn all<T>(input: &[T]) -> BTreeSet<BTreeSet<T>> where T: Ord + Eq + Clone {
     let mut permutations = BTreeSet::new();
 
     if input.len() == 0 {
@@ -17,7 +17,7 @@ pub fn permute<T>(input: &[T]) -> BTreeSet<BTreeSet<T>> where T: Ord + Eq + Clon
                 .cloned()
                 .collect::<Vec<_>>();
 
-            for pt in permute(&p) {
+            for pt in all(&p) {
                 permutations.insert(pt);
             }
         }

--- a/ci/src/permute.rs
+++ b/ci/src/permute.rs
@@ -1,0 +1,27 @@
+use std::collections::BTreeSet;
+
+pub fn permute<T>(input: &[T]) -> BTreeSet<BTreeSet<T>> where T: Ord + Eq + Clone {
+    let mut permutations = BTreeSet::new();
+
+    if input.len() == 0 {
+        return permutations;
+    }
+
+    permutations.insert(input.iter().cloned().collect());
+
+    if input.len() > 1 {
+        for t in input {
+            let mut p = input
+                .iter()
+                .filter(|pt| *pt != t)
+                .cloned()
+                .collect::<Vec<_>>();
+
+            for pt in permute(&p) {
+                permutations.insert(pt);
+            }
+        }
+    }
+
+    permutations
+}

--- a/ci/src/task.rs
+++ b/ci/src/task.rs
@@ -1,0 +1,67 @@
+use std::collections::BTreeSet;
+use std::process::{
+    Command,
+    Stdio,
+};
+
+pub type Feature = &'static str;
+
+pub struct TestArgs {
+    pub features: BTreeSet<Feature>,
+    pub default_features: bool,
+    pub lib_only: bool,
+}
+
+impl Default for TestArgs {
+    fn default() -> Self {
+        TestArgs {
+            features: BTreeSet::new(),
+            default_features: true,
+            lib_only: false,
+        }
+    }
+}
+
+impl TestArgs {
+    fn features_string(&self) -> Option<String> {
+        if self.features.len() == 0 {
+            return None;
+        }
+
+        Some(self.features.iter().map(|f| *f).collect::<Vec<_>>().join(" "))
+    }
+}
+
+pub fn test(args: TestArgs) {
+    let features = args.features_string();
+
+    let mut command = Command::new("cargo");
+        
+    command
+        .stdout(Stdio::inherit())
+        .stderr(Stdio::inherit())
+        .arg("test")
+        .arg("--verbose");
+
+    if !args.default_features {
+        command.arg("--no-default-features");
+    }
+
+    if args.lib_only {
+        command.arg("--lib");
+    }
+
+    if let Some(ref features) = features {
+        command.args(&["--features", features]);
+    }
+
+    println!("running {:?}", command);
+    
+    let status = command
+        .status()
+        .expect("Failed to execute command");
+
+    if !status.success() {
+        eprintln!("test execution failed for features: {}", features.as_ref().map(AsRef::as_ref).unwrap_or(""));
+    }
+}

--- a/ci/src/task.rs
+++ b/ci/src/task.rs
@@ -28,11 +28,20 @@ impl TestArgs {
             return None;
         }
 
-        Some(self.features.iter().map(|f| *f).collect::<Vec<_>>().join(" "))
+        let s = self.features.iter().fold(String::new(), |mut s, f| {
+            if s.len() > 0 {
+                s.push_str(" ");
+            }
+            s.push_str(f);
+
+            s
+        });
+
+        Some(s)
     }
 }
 
-pub fn test(args: TestArgs) {
+pub fn test(args: TestArgs) -> bool {
     let features = args.features_string();
 
     let mut command = Command::new("cargo");
@@ -63,5 +72,8 @@ pub fn test(args: TestArgs) {
 
     if !status.success() {
         eprintln!("test execution failed for features: {}", features.as_ref().map(AsRef::as_ref).unwrap_or(""));
+        false
+    } else {
+        true
     }
 }

--- a/examples/custom_format.rs
+++ b/examples/custom_format.rs
@@ -33,6 +33,8 @@ fn init_logger() {
     let mut builder = Builder::from_env(env);
 
     // Use a different format for writing log records
+    // The colors are only available when the `termcolor` dependency is (which it is by default)
+    #[cfg(feature = "termcolor")]
     builder.format(|buf, record| {
         let mut style = buf.style();
         style.set_bg(fmt::Color::Yellow).set_bold(true);

--- a/src/fmt/atty.rs
+++ b/src/fmt/atty.rs
@@ -1,0 +1,25 @@
+#[cfg(feature = "atty")]
+mod imp {
+    use atty;
+
+    pub(in ::fmt) fn is_stdout() -> bool {
+        atty::is(atty::Stream::Stdout)
+    }
+
+    pub(in ::fmt) fn is_stderr() -> bool {
+        atty::is(atty::Stream::Stderr)
+    }
+}
+
+#[cfg(not(feature = "atty"))]
+mod imp {
+    pub(in ::fmt) fn is_stdout() -> bool {
+        true
+    }
+
+    pub(in ::fmt) fn is_stderr() -> bool {
+        true
+    }
+}
+
+pub(in ::fmt) use self::imp::*;

--- a/src/fmt/atty.rs
+++ b/src/fmt/atty.rs
@@ -1,3 +1,12 @@
+/*
+This internal module contains the terminal detection implementation.
+
+If the `atty` crate is available then we use it to detect whether we're
+attached to a particular TTY. If the `atty` crate is not available we
+assume we're not attached to anything. This effectively prevents styles
+from being printed.
+*/
+
 #[cfg(feature = "atty")]
 mod imp {
     use atty;
@@ -14,11 +23,11 @@ mod imp {
 #[cfg(not(feature = "atty"))]
 mod imp {
     pub(in ::fmt) fn is_stdout() -> bool {
-        true
+        false
     }
 
     pub(in ::fmt) fn is_stderr() -> bool {
-        true
+        false
     }
 }
 

--- a/src/fmt/humantime/extern_impl.rs
+++ b/src/fmt/humantime/extern_impl.rs
@@ -5,7 +5,7 @@ use humantime::{format_rfc3339_nanos, format_rfc3339_seconds};
 
 use ::fmt::Formatter;
 
-pub(in ::fmt) mod pub_use {
+pub(in ::fmt) mod pub_use_in_super {
     pub use super::*;
 }
 

--- a/src/fmt/humantime/extern_impl.rs
+++ b/src/fmt/humantime/extern_impl.rs
@@ -1,0 +1,82 @@
+use std::fmt;
+use std::time::SystemTime;
+
+use humantime::{format_rfc3339_nanos, format_rfc3339_seconds};
+
+use ::fmt::Formatter;
+
+pub(in ::fmt) mod pub_use {
+    pub use super::*;
+}
+
+impl Formatter {
+    /// Get a [`Timestamp`] for the current date and time in UTC.
+    ///
+    /// # Examples
+    ///
+    /// Include the current timestamp with the log record:
+    ///
+    /// ```
+    /// use std::io::Write;
+    ///
+    /// let mut builder = env_logger::Builder::new();
+    ///
+    /// builder.format(|buf, record| {
+    ///     let ts = buf.timestamp();
+    ///
+    ///     writeln!(buf, "{}: {}: {}", ts, record.level(), record.args())
+    /// });
+    /// ```
+    ///
+    /// [`Timestamp`]: struct.Timestamp.html
+    pub fn timestamp(&self) -> Timestamp {
+        Timestamp(SystemTime::now())
+    }
+
+    /// Get a [`PreciseTimestamp`] for the current date and time in UTC with nanos.
+    pub fn precise_timestamp(&self) -> PreciseTimestamp {
+        PreciseTimestamp(SystemTime::now())
+    }
+}
+
+/// An [RFC3339] formatted timestamp.
+///
+/// The timestamp implements [`Display`] and can be written to a [`Formatter`].
+///
+/// [RFC3339]: https://www.ietf.org/rfc/rfc3339.txt
+/// [`Display`]: https://doc.rust-lang.org/stable/std/fmt/trait.Display.html
+/// [`Formatter`]: struct.Formatter.html
+pub struct Timestamp(SystemTime);
+
+/// An [RFC3339] formatted timestamp with nanos
+#[derive(Debug)]
+pub struct PreciseTimestamp(SystemTime);
+
+impl fmt::Debug for Timestamp {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        /// A `Debug` wrapper for `Timestamp` that uses the `Display` implementation.
+        struct TimestampValue<'a>(&'a Timestamp);
+
+        impl<'a> fmt::Debug for TimestampValue<'a> {
+            fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+                fmt::Display::fmt(&self.0, f)
+            }
+        }
+
+        f.debug_tuple("Timestamp")
+        .field(&TimestampValue(&self))
+        .finish()
+    }
+}
+
+impl fmt::Display for Timestamp {
+    fn fmt(&self, f: &mut fmt::Formatter)->fmt::Result {
+        format_rfc3339_seconds(self.0).fmt(f)
+    }
+}
+
+impl fmt::Display for PreciseTimestamp {
+    fn fmt(&self, f: &mut fmt::Formatter)->fmt::Result {
+        format_rfc3339_nanos(self.0).fmt(f)
+    }
+}

--- a/src/fmt/humantime/mod.rs
+++ b/src/fmt/humantime/mod.rs
@@ -1,3 +1,9 @@
+/*
+This internal module contains the timestamp implementation.
+
+Its public API is available when the `humantime` crate is available.
+*/
+
 #[cfg_attr(feature = "humantime", path = "extern_impl.rs")]
 #[cfg_attr(not(feature = "humantime"), path = "shim_impl.rs")]
 mod imp;

--- a/src/fmt/humantime/mod.rs
+++ b/src/fmt/humantime/mod.rs
@@ -1,0 +1,5 @@
+#[cfg_attr(feature = "humantime", path = "extern_impl.rs")]
+#[cfg_attr(not(feature = "humantime"), path = "shim_impl.rs")]
+mod imp;
+
+pub(in ::fmt) use self::imp::*;

--- a/src/fmt/humantime/shim_impl.rs
+++ b/src/fmt/humantime/shim_impl.rs
@@ -1,5 +1,7 @@
-pub(in ::fmt) mod pub_use {
-    /*
-    Timestamps aren't available when we don't have a `humantime` dependency.
-    */
+/*
+Timestamps aren't available when we don't have a `humantime` dependency.
+*/
+
+pub(in ::fmt) mod pub_use_in_super {
+    
 }

--- a/src/fmt/humantime/shim_impl.rs
+++ b/src/fmt/humantime/shim_impl.rs
@@ -1,0 +1,5 @@
+pub(in ::fmt) mod pub_use {
+    /*
+    Timestamps aren't available when we don't have a `humantime` dependency.
+    */
+}

--- a/src/fmt/mod.rs
+++ b/src/fmt/mod.rs
@@ -1,0 +1,291 @@
+//! Formatting for log records.
+//!
+//! This module contains a [`Formatter`] that can be used to format log records
+//! into without needing temporary allocations. Usually you won't need to worry
+//! about the contents of this module and can use the `Formatter` like an ordinary
+//! [`Write`].
+//!
+//! # Formatting log records
+//!
+//! The format used to print log records can be customised using the [`Builder::format`]
+//! method.
+//! Custom formats can apply different color and weight to printed values using
+//! [`Style`] builders.
+//!
+//! ```
+//! use std::io::Write;
+//! use env_logger::fmt::Color;
+//!
+//! let mut builder = env_logger::Builder::new();
+//!
+//! builder.format(|buf, record| {
+//!     let mut level_style = buf.style();
+//!
+//!     level_style.set_color(Color::Red).set_bold(true);
+//!
+//!     writeln!(buf, "{}: {}",
+//!         level_style.value(record.level()),
+//!         record.args())
+//! });
+//! ```
+//!
+//! [`Formatter`]: struct.Formatter.html
+//! [`Style`]: struct.Style.html
+//! [`Builder::format`]: ../struct.Builder.html#method.format
+//! [`Write`]: https://doc.rust-lang.org/stable/std/io/trait.Write.html
+
+use std::io::prelude::*;
+use std::{io, fmt};
+use std::rc::Rc;
+use std::cell::RefCell;
+
+mod termcolor;
+mod atty;
+mod humantime;
+
+use self::termcolor::{Buffer, BufferWriter};
+use self::atty::{is_stdout, is_stderr};
+
+pub use self::humantime::pub_use::*;
+pub use self::termcolor::pub_use::*;
+
+pub(super) mod pub_use {
+    pub use super::{Target, WriteStyle, Formatter};
+
+    #[cfg(feature = "termcolor")]
+    pub use super::Color;
+}
+
+/// A formatter to write logs into.
+///
+/// `Formatter` implements the standard [`Write`] trait for writing log records.
+/// It also supports terminal colors, through the [`style`] method.
+///
+/// # Examples
+///
+/// Use the [`writeln`] macro to easily format a log record:
+///
+/// ```
+/// use std::io::Write;
+///
+/// let mut builder = env_logger::Builder::new();
+///
+/// builder.format(|buf, record| writeln!(buf, "{}: {}", record.level(), record.args()));
+/// ```
+///
+/// [`Write`]: https://doc.rust-lang.org/stable/std/io/trait.Write.html
+/// [`writeln`]: https://doc.rust-lang.org/stable/std/macro.writeln.html
+/// [`style`]: #method.style
+pub struct Formatter {
+    buf: Rc<RefCell<Buffer>>,
+    write_style: WriteStyle,
+}
+
+/// Log target, either `stdout` or `stderr`.
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
+pub enum Target {
+    /// Logs will be sent to standard output.
+    Stdout,
+    /// Logs will be sent to standard error.
+    Stderr,
+}
+
+impl Default for Target {
+    fn default() -> Self {
+        Target::Stderr
+    }
+}
+
+/// Whether or not to print styles to the target.
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
+pub enum WriteStyle {
+    /// Try to print styles, but don't force the issue.
+    Auto,
+    /// Try very hard to print styles.
+    Always,
+    /// Never print styles.
+    Never,
+}
+
+impl Default for WriteStyle {
+    fn default() -> Self {
+        WriteStyle::Auto
+    }
+}
+
+/// A terminal target with color awareness.
+pub(crate) struct Writer {
+    inner: BufferWriter,
+    write_style: WriteStyle,
+}
+
+impl Writer {
+    pub(crate) fn write_style(&self) -> WriteStyle {
+        self.write_style
+    }
+}
+
+/// A builder for a terminal writer.
+///
+/// The target and style choice can be configured before building.
+pub(crate) struct Builder {
+    target: Target,
+    write_style: WriteStyle,
+}
+
+impl Builder {
+    /// Initialize the writer builder with defaults.
+    pub fn new() -> Self {
+        Builder {
+            target: Default::default(),
+            write_style: Default::default(),
+        }
+    }
+
+    /// Set the target to write to.
+    pub fn target(&mut self, target: Target) -> &mut Self {
+        self.target = target;
+        self
+    }
+
+    /// Parses a style choice string.
+    ///
+    /// See the [Disabling colors] section for more details.
+    ///
+    /// [Disabling colors]: ../index.html#disabling-colors
+    pub fn parse(&mut self, write_style: &str) -> &mut Self {
+        self.write_style(parse_write_style(write_style))
+    }
+
+    /// Whether or not to print style characters when writing.
+    pub fn write_style(&mut self, write_style: WriteStyle) -> &mut Self {
+        self.write_style = write_style;
+        self
+    }
+
+    /// Build a terminal writer.
+    pub fn build(&mut self) -> Writer {
+        let color_choice = match self.write_style {
+            WriteStyle::Auto => {
+                if match self.target {
+                    Target::Stderr => is_stderr(),
+                    Target::Stdout => is_stdout(),
+                } {
+                    WriteStyle::Auto
+                } else {
+                    WriteStyle::Never
+                }
+            },
+            color_choice => color_choice,
+        };
+
+        let writer = match self.target {
+            Target::Stderr => BufferWriter::stderr(color_choice),
+            Target::Stdout => BufferWriter::stdout(color_choice),
+        };
+
+        Writer {
+            inner: writer,
+            write_style: self.write_style,
+        }
+    }
+}
+
+impl Default for Builder {
+    fn default() -> Self {
+        Builder::new()
+    }
+}
+
+impl Formatter {
+    pub(crate) fn new(writer: &Writer) -> Self {
+        Formatter {
+            buf: Rc::new(RefCell::new(writer.inner.buffer())),
+            write_style: writer.write_style(),
+        }
+    }
+
+    pub(crate) fn write_style(&self) -> WriteStyle {
+        self.write_style
+    }
+
+    pub(crate) fn print(&self, writer: &Writer) -> io::Result<()> {
+        writer.inner.print(&self.buf.borrow())
+    }
+
+    pub(crate) fn clear(&mut self) {
+        self.buf.borrow_mut().clear()
+    }
+}
+
+impl Write for Formatter {
+    fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
+        self.buf.borrow_mut().write(buf)
+    }
+
+    fn flush(&mut self) -> io::Result<()> {
+        self.buf.borrow_mut().flush()
+    }
+}
+
+impl fmt::Debug for Writer {
+    fn fmt(&self, f: &mut fmt::Formatter)->fmt::Result {
+        f.debug_struct("Writer").finish()
+    }
+}
+
+impl fmt::Debug for Formatter {
+    fn fmt(&self, f: &mut fmt::Formatter)->fmt::Result {
+        f.debug_struct("Formatter").finish()
+    }
+}
+
+impl fmt::Debug for Builder {
+    fn fmt(&self, f: &mut fmt::Formatter)->fmt::Result {
+        f.debug_struct("Logger")
+        .field("target", &self.target)
+        .field("write_style", &self.write_style)
+        .finish()
+    }
+}
+
+fn parse_write_style(spec: &str) -> WriteStyle {
+    match spec {
+        "auto" => WriteStyle::Auto,
+        "always" => WriteStyle::Always,
+        "never" => WriteStyle::Never,
+        _ => Default::default(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_write_style_valid() {
+        let inputs = vec![
+            ("auto", WriteStyle::Auto),
+            ("always", WriteStyle::Always),
+            ("never", WriteStyle::Never),
+        ];
+
+        for (input, expected) in inputs {
+            assert_eq!(expected, parse_write_style(input));
+        }
+    }
+
+    #[test]
+    fn parse_write_style_invalid() {
+        let inputs = vec![
+            "",
+            "true",
+            "false",
+            "NEVER!!"
+        ];
+
+        for input in inputs {
+            assert_eq!(WriteStyle::Auto, parse_write_style(input));
+        }
+    }
+}

--- a/src/fmt/mod.rs
+++ b/src/fmt/mod.rs
@@ -46,10 +46,10 @@ mod humantime;
 use self::termcolor::{Buffer, BufferWriter};
 use self::atty::{is_stdout, is_stderr};
 
-pub use self::humantime::pub_use::*;
-pub use self::termcolor::pub_use::*;
+pub use self::humantime::pub_use_in_super::*;
+pub use self::termcolor::pub_use_in_super::*;
 
-pub(super) mod pub_use {
+pub(super) mod pub_use_in_super {
     pub use super::{Target, WriteStyle, Formatter};
 
     #[cfg(feature = "termcolor")]

--- a/src/fmt/mod.rs
+++ b/src/fmt/mod.rs
@@ -14,17 +14,12 @@
 //!
 //! ```
 //! use std::io::Write;
-//! use env_logger::fmt::Color;
 //!
 //! let mut builder = env_logger::Builder::new();
 //!
 //! builder.format(|buf, record| {
-//!     let mut level_style = buf.style();
-//!
-//!     level_style.set_color(Color::Red).set_bold(true);
-//!
 //!     writeln!(buf, "{}: {}",
-//!         level_style.value(record.level()),
+//!         record.level(),
 //!         record.args())
 //! });
 //! ```

--- a/src/fmt/termcolor/extern_impl.rs
+++ b/src/fmt/termcolor/extern_impl.rs
@@ -1,75 +1,107 @@
-//! Formatting for log records.
-//!
-//! This module contains a [`Formatter`] that can be used to format log records
-//! into without needing temporary allocations. Usually you won't need to worry
-//! about the contents of this module and can use the `Formatter` like an ordinary
-//! [`Write`].
-//!
-//! # Formatting log records
-//!
-//! The format used to print log records can be customised using the [`Builder::format`]
-//! method.
-//! Custom formats can apply different color and weight to printed values using
-//! [`Style`] builders.
-//!
-//! ```
-//! use std::io::Write;
-//! use env_logger::fmt::Color;
-//!
-//! let mut builder = env_logger::Builder::new();
-//!
-//! builder.format(|buf, record| {
-//!     let mut level_style = buf.style();
-//!
-//!     level_style.set_color(Color::Red).set_bold(true);
-//!
-//!     writeln!(buf, "{}: {}",
-//!         level_style.value(record.level()),
-//!         record.args())
-//! });
-//! ```
-//!
-//! [`Formatter`]: struct.Formatter.html
-//! [`Style`]: struct.Style.html
-//! [`Builder::format`]: ../struct.Builder.html#method.format
-//! [`Write`]: https://doc.rust-lang.org/stable/std/io/trait.Write.html
-
-use std::io::prelude::*;
-use std::{io, fmt};
-use std::rc::Rc;
-use std::str::FromStr;
 use std::error::Error;
+use std::fmt;
+use std::io;
+use std::str::FromStr;
 use std::cell::RefCell;
-use std::time::SystemTime;
+use std::rc::Rc;
 
 use log::Level;
-use termcolor::{self, ColorSpec, ColorChoice, Buffer, BufferWriter, WriteColor};
-use atty;
-use humantime::{format_rfc3339_seconds, format_rfc3339_nanos};
+use termcolor::{self, ColorSpec};
 
-/// A formatter to write logs into.
-///
-/// `Formatter` implements the standard [`Write`] trait for writing log records.
-/// It also supports terminal colors, through the [`style`] method.
-///
-/// # Examples
-///
-/// Use the [`writeln`] macro to easily format a log record:
-///
-/// ```
-/// use std::io::Write;
-///
-/// let mut builder = env_logger::Builder::new();
-///
-/// builder.format(|buf, record| writeln!(buf, "{}: {}", record.level(), record.args()));
-/// ```
-///
-/// [`Write`]: https://doc.rust-lang.org/stable/std/io/trait.Write.html
-/// [`writeln`]: https://doc.rust-lang.org/stable/std/macro.writeln.html
-/// [`style`]: #method.style
-pub struct Formatter {
-    buf: Rc<RefCell<Buffer>>,
-    write_style: WriteStyle,
+use ::WriteStyle;
+use ::fmt::Formatter;
+
+pub(in ::fmt) mod pub_use {
+    pub use super::*;
+}
+
+impl Formatter {
+    /// Begin a new [`Style`].
+    ///
+    /// # Examples
+    ///
+    /// Create a bold, red colored style and use it to print the log level:
+    ///
+    /// ```
+    /// use std::io::Write;
+    /// use env_logger::fmt::Color;
+    ///
+    /// let mut builder = env_logger::Builder::new();
+    ///
+    /// builder.format(|buf, record| {
+    ///     let mut level_style = buf.style();
+    ///
+    ///     level_style.set_color(Color::Red).set_bold(true);
+    ///
+    ///     writeln!(buf, "{}: {}",
+    ///         level_style.value(record.level()),
+    ///         record.args())
+    /// });
+    /// ```
+    ///
+    /// [`Style`]: struct.Style.html
+    pub fn style(&self) -> Style {
+        Style {
+            buf: self.buf.clone(),
+            spec: ColorSpec::new(),
+        }
+    }
+
+    /// Get the default [`Style`] for the given level.
+    pub fn default_level_style(&self, level: Level) -> Style {
+        let mut level_style = self.style();
+        match level {
+            Level::Trace => level_style.set_color(Color::White),
+            Level::Debug => level_style.set_color(Color::Blue),
+            Level::Info => level_style.set_color(Color::Green),
+            Level::Warn => level_style.set_color(Color::Yellow),
+            Level::Error => level_style.set_color(Color::Red).set_bold(true),
+        };
+        level_style
+    }
+}
+
+pub(in ::fmt) struct BufferWriter(termcolor::BufferWriter);
+pub(in ::fmt) struct Buffer(termcolor::Buffer);
+
+impl BufferWriter {
+    pub(in ::fmt) fn stderr(color_choice: WriteStyle) -> Self {
+        unimplemented!()
+    }
+
+    pub(in ::fmt) fn stdout(color_choice: WriteStyle) -> Self {
+        unimplemented!()
+    }
+
+    pub(in ::fmt) fn buffer(&self) -> Buffer {
+        unimplemented!()
+    }
+
+    pub(in ::fmt) fn print(&self, buf: &Buffer) -> io::Result<()> {
+        unimplemented!()
+    }
+}
+
+impl Buffer {
+    pub(in ::fmt) fn clear(&mut self) {
+        unimplemented!()
+    }
+
+    pub(in ::fmt) fn set_color(&mut self, spec: &ColorSpec) -> io::Result<()> {
+        unimplemented!()
+    }
+
+    pub(in ::fmt) fn reset(&mut self) -> io::Result<()> {
+        unimplemented!()
+    }
+
+    pub(in ::fmt) fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
+        unimplemented!()
+    }
+
+    pub(in ::fmt) fn flush(&mut self) -> io::Result<()> {
+        unimplemented!()
+    }
 }
 
 /// A set of styles to apply to the terminal output.
@@ -138,136 +170,6 @@ pub struct Style {
 pub struct StyledValue<'a, T> {
     style: &'a Style,
     value: T,
-}
-
-/// An [RFC3339] formatted timestamp.
-///
-/// The timestamp implements [`Display`] and can be written to a [`Formatter`].
-///
-/// [RFC3339]: https://www.ietf.org/rfc/rfc3339.txt
-/// [`Display`]: https://doc.rust-lang.org/stable/std/fmt/trait.Display.html
-/// [`Formatter`]: struct.Formatter.html
-pub struct Timestamp(SystemTime);
-
-/// An [RFC3339] formatted timestamp with nanos
-#[derive(Debug)]
-pub struct PreciseTimestamp(SystemTime);
-
-/// Log target, either `stdout` or `stderr`.
-#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
-pub enum Target {
-    /// Logs will be sent to standard output.
-    Stdout,
-    /// Logs will be sent to standard error.
-    Stderr,
-}
-
-impl Default for Target {
-    fn default() -> Self {
-        Target::Stderr
-    }
-}
-
-/// Whether or not to print styles to the target.
-#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
-pub enum WriteStyle {
-    /// Try to print styles, but don't force the issue.
-    Auto,
-    /// Try very hard to print styles.
-    Always,
-    /// Never print styles.
-    Never,
-}
-
-impl Default for WriteStyle {
-    fn default() -> Self {
-        WriteStyle::Auto
-    }
-}
-
-/// A terminal target with color awareness.
-pub(crate) struct Writer {
-    inner: BufferWriter,
-    write_style: WriteStyle,
-}
-
-impl Writer {
-    pub(crate) fn write_style(&self) -> WriteStyle {
-        self.write_style
-    }
-}
-
-/// A builder for a terminal writer.
-///
-/// The target and style choice can be configured before building.
-pub(crate) struct Builder {
-    target: Target,
-    write_style: WriteStyle,
-}
-
-impl Builder {
-    /// Initialize the writer builder with defaults.
-    pub fn new() -> Self {
-        Builder {
-            target: Default::default(),
-            write_style: Default::default(),
-        }
-    }
-
-    /// Set the target to write to.
-    pub fn target(&mut self, target: Target) -> &mut Self {
-        self.target = target;
-        self
-    }
-
-    /// Parses a style choice string.
-    ///
-    /// See the [Disabling colors] section for more details.
-    ///
-    /// [Disabling colors]: ../index.html#disabling-colors
-    pub fn parse(&mut self, write_style: &str) -> &mut Self {
-        self.write_style(parse_write_style(write_style))
-    }
-
-    /// Whether or not to print style characters when writing.
-    pub fn write_style(&mut self, write_style: WriteStyle) -> &mut Self {
-        self.write_style = write_style;
-        self
-    }
-
-    /// Build a terminal writer.
-    pub fn build(&mut self) -> Writer {
-        let color_choice = match self.write_style {
-            WriteStyle::Auto => {
-                if atty::is(match self.target {
-                    Target::Stderr => atty::Stream::Stderr,
-                    Target::Stdout => atty::Stream::Stdout,
-                }) {
-                    ColorChoice::Auto
-                } else {
-                    ColorChoice::Never
-                }
-            },
-            WriteStyle::Always => ColorChoice::Always,
-            WriteStyle::Never => ColorChoice::Never,
-        };
-
-        let writer = match self.target {
-            Target::Stderr => BufferWriter::stderr(color_choice),
-            Target::Stdout => BufferWriter::stdout(color_choice),
-        };
-
-        Writer {
-            inner: writer,
-            write_style: self.write_style,
-        }
-    }
-}
-
-impl Default for Builder {
-    fn default() -> Self {
-        Builder::new()
-    }
 }
 
 impl Style {
@@ -407,109 +309,6 @@ impl Style {
     }
 }
 
-impl Formatter {
-    pub(crate) fn new(writer: &Writer) -> Self {
-        Formatter {
-            buf: Rc::new(RefCell::new(writer.inner.buffer())),
-            write_style: writer.write_style(),
-        }
-    }
-
-    pub(crate) fn write_style(&self) -> WriteStyle {
-        self.write_style
-    }
-
-    /// Begin a new [`Style`].
-    ///
-    /// # Examples
-    ///
-    /// Create a bold, red colored style and use it to print the log level:
-    ///
-    /// ```
-    /// use std::io::Write;
-    /// use env_logger::fmt::Color;
-    ///
-    /// let mut builder = env_logger::Builder::new();
-    ///
-    /// builder.format(|buf, record| {
-    ///     let mut level_style = buf.style();
-    ///
-    ///     level_style.set_color(Color::Red).set_bold(true);
-    ///
-    ///     writeln!(buf, "{}: {}",
-    ///         level_style.value(record.level()),
-    ///         record.args())
-    /// });
-    /// ```
-    ///
-    /// [`Style`]: struct.Style.html
-    pub fn style(&self) -> Style {
-        Style {
-            buf: self.buf.clone(),
-            spec: ColorSpec::new(),
-        }
-    }
-
-    /// Get the default [`Style`] for the given level.
-    pub fn default_level_style(&self, level: Level) -> Style {
-        let mut level_style = self.style();
-        match level {
-            Level::Trace => level_style.set_color(Color::White),
-            Level::Debug => level_style.set_color(Color::Blue),
-            Level::Info => level_style.set_color(Color::Green),
-            Level::Warn => level_style.set_color(Color::Yellow),
-            Level::Error => level_style.set_color(Color::Red).set_bold(true),
-        };
-        level_style
-    }
-
-    /// Get a [`Timestamp`] for the current date and time in UTC.
-    ///
-    /// # Examples
-    ///
-    /// Include the current timestamp with the log record:
-    ///
-    /// ```
-    /// use std::io::Write;
-    ///
-    /// let mut builder = env_logger::Builder::new();
-    ///
-    /// builder.format(|buf, record| {
-    ///     let ts = buf.timestamp();
-    ///
-    ///     writeln!(buf, "{}: {}: {}", ts, record.level(), record.args())
-    /// });
-    /// ```
-    ///
-    /// [`Timestamp`]: struct.Timestamp.html
-    pub fn timestamp(&self) -> Timestamp {
-        Timestamp(SystemTime::now())
-    }
-
-     /// Get a [`PreciseTimestamp`] for the current date and time in UTC with nanos.
-    pub fn precise_timestamp(&self) -> PreciseTimestamp {
-        PreciseTimestamp(SystemTime::now())
-    }
-
-    pub(crate) fn print(&self, writer: &Writer) -> io::Result<()> {
-        writer.inner.print(&self.buf.borrow())
-    }
-
-    pub(crate) fn clear(&mut self) {
-        self.buf.borrow_mut().clear()
-    }
-}
-
-impl Write for Formatter {
-    fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
-        self.buf.borrow_mut().write(buf)
-    }
-
-    fn flush(&mut self) -> io::Result<()> {
-        self.buf.borrow_mut().flush()
-    }
-}
-
 impl<'a, T> StyledValue<'a, T> {
     fn write_fmt<F>(&self, f: F) -> fmt::Result
     where
@@ -522,44 +321,6 @@ impl<'a, T> StyledValue<'a, T> {
         let reset = self.style.buf.borrow_mut().reset().map_err(|_| fmt::Error);
 
         write.and(reset)
-    }
-}
-
-impl fmt::Debug for Timestamp {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        /// A `Debug` wrapper for `Timestamp` that uses the `Display` implementation.
-        struct TimestampValue<'a>(&'a Timestamp);
-
-        impl<'a> fmt::Debug for TimestampValue<'a> {
-            fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-                fmt::Display::fmt(&self.0, f)
-            }
-        }
-
-        f.debug_tuple("Timestamp")
-         .field(&TimestampValue(&self))
-         .finish()
-    }
-}
-
-impl fmt::Debug for Writer {
-    fn fmt(&self, f: &mut fmt::Formatter)->fmt::Result {
-        f.debug_struct("Writer").finish()
-    }
-}
-
-impl fmt::Debug for Formatter {
-    fn fmt(&self, f: &mut fmt::Formatter)->fmt::Result {
-        f.debug_struct("Formatter").finish()
-    }
-}
-
-impl fmt::Debug for Builder {
-    fn fmt(&self, f: &mut fmt::Formatter)->fmt::Result {
-        f.debug_struct("Logger")
-        .field("target", &self.target)
-        .field("write_style", &self.write_style)
-        .finish()
     }
 }
 
@@ -591,18 +352,6 @@ impl_styled_value_fmt!(
     fmt::LowerHex,
     fmt::UpperExp,
     fmt::LowerExp);
-
-impl fmt::Display for Timestamp {
-    fn fmt(&self, f: &mut fmt::Formatter)->fmt::Result {
-        format_rfc3339_seconds(self.0).fmt(f)
-    }
-}
-
-impl fmt::Display for PreciseTimestamp {
-    fn fmt(&self, f: &mut fmt::Formatter)->fmt::Result {
-        format_rfc3339_nanos(self.0).fmt(f)
-    }
-}
 
 // The `Color` type is copied from https://github.com/BurntSushi/ripgrep/tree/master/termcolor
 
@@ -742,45 +491,9 @@ impl FromStr for Color {
     }
 }
 
-fn parse_write_style(spec: &str) -> WriteStyle {
-    match spec {
-        "auto" => WriteStyle::Auto,
-        "always" => WriteStyle::Always,
-        "never" => WriteStyle::Never,
-        _ => Default::default(),
-    }
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
-
-    #[test]
-    fn parse_write_style_valid() {
-        let inputs = vec![
-            ("auto", WriteStyle::Auto),
-            ("always", WriteStyle::Always),
-            ("never", WriteStyle::Never),
-        ];
-
-        for (input, expected) in inputs {
-            assert_eq!(expected, parse_write_style(input));
-        }
-    }
-
-    #[test]
-    fn parse_write_style_invalid() {
-        let inputs = vec![
-            "",
-            "true",
-            "false",
-            "NEVER!!"
-        ];
-
-        for input in inputs {
-            assert_eq!(WriteStyle::Auto, parse_write_style(input));
-        }
-    }
 
     #[test]
     fn parse_color_name_valid() {

--- a/src/fmt/termcolor/extern_impl.rs
+++ b/src/fmt/termcolor/extern_impl.rs
@@ -1,13 +1,13 @@
 use std::error::Error;
 use std::borrow::Cow;
 use std::fmt;
-use std::io;
+use std::io::{self, Write};
 use std::str::FromStr;
 use std::cell::RefCell;
 use std::rc::Rc;
 
 use log::Level;
-use termcolor::{self, ColorSpec};
+use termcolor::{self, ColorChoice, ColorSpec, WriteColor};
 
 use ::WriteStyle;
 use ::fmt::Formatter;
@@ -75,42 +75,52 @@ pub(in ::fmt) struct BufferWriter(termcolor::BufferWriter);
 pub(in ::fmt) struct Buffer(termcolor::Buffer);
 
 impl BufferWriter {
-    pub(in ::fmt) fn stderr(color_choice: WriteStyle) -> Self {
-        unimplemented!()
+    pub(in ::fmt) fn stderr(write_style: WriteStyle) -> Self {
+        BufferWriter(termcolor::BufferWriter::stderr(write_style.into_color_choice()))
     }
 
-    pub(in ::fmt) fn stdout(color_choice: WriteStyle) -> Self {
-        unimplemented!()
+    pub(in ::fmt) fn stdout(write_style: WriteStyle) -> Self {
+        BufferWriter(termcolor::BufferWriter::stdout(write_style.into_color_choice()))
     }
 
     pub(in ::fmt) fn buffer(&self) -> Buffer {
-        unimplemented!()
+        Buffer(self.0.buffer())
     }
 
     pub(in ::fmt) fn print(&self, buf: &Buffer) -> io::Result<()> {
-        unimplemented!()
+        self.0.print(&buf.0)
     }
 }
 
 impl Buffer {
     pub(in ::fmt) fn clear(&mut self) {
-        unimplemented!()
+        self.0.clear()
     }
 
     pub(in ::fmt) fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
-        unimplemented!()
+        self.0.write(buf)
     }
 
     pub(in ::fmt) fn flush(&mut self) -> io::Result<()> {
-        unimplemented!()
+        self.0.flush()
     }
 
     fn set_color(&mut self, spec: &ColorSpec) -> io::Result<()> {
-        unimplemented!()
+        self.0.set_color(spec)
     }
 
     fn reset(&mut self) -> io::Result<()> {
-        unimplemented!()
+        self.0.reset()
+    }
+}
+
+impl WriteStyle {
+    fn into_color_choice(self) -> ColorChoice {
+        match self {
+            WriteStyle::Always => ColorChoice::Always,
+            WriteStyle::Auto => ColorChoice::Auto,
+            WriteStyle::Never => ColorChoice::Never,
+        }
     }
 }
 

--- a/src/fmt/termcolor/mod.rs
+++ b/src/fmt/termcolor/mod.rs
@@ -1,3 +1,10 @@
+/*
+This internal module contains the style and terminal writing implementation.
+
+Its public API is available when the `termcolor` crate is available.
+The terminal printing is shimmed when the `termcolor` crate is not available.
+*/
+
 #[cfg_attr(feature = "termcolor", path = "extern_impl.rs")]
 #[cfg_attr(not(feature = "termcolor"), path = "shim_impl.rs")]
 mod imp;

--- a/src/fmt/termcolor/mod.rs
+++ b/src/fmt/termcolor/mod.rs
@@ -1,0 +1,5 @@
+#[cfg_attr(feature = "termcolor", path = "extern_impl.rs")]
+#[cfg_attr(not(feature = "termcolor"), path = "shim_impl.rs")]
+mod imp;
+
+pub(in ::fmt) use self::imp::*;

--- a/src/fmt/termcolor/shim_impl.rs
+++ b/src/fmt/termcolor/shim_impl.rs
@@ -1,43 +1,53 @@
-use std::fmt;
-use std::io;
+use std::io::{self, Write};
 
-use ::WriteStyle;
+use fmt::{WriteStyle, Target};
 
 pub(in ::fmt) mod pub_use_in_super {
     
 }
 
-pub(in ::fmt) struct BufferWriter {}
-pub(in ::fmt) struct Buffer {}
+pub(in ::fmt) struct BufferWriter {
+    target: Target,
+}
+
+pub(in ::fmt) struct Buffer(Vec<u8>);
 
 impl BufferWriter {
-    pub(in ::fmt) fn stderr(color_choice: WriteStyle) -> Self {
-        unimplemented!()
+    pub(in ::fmt) fn stderr(_: WriteStyle) -> Self {
+        BufferWriter {
+            target: Target::Stderr,
+        }
     }
 
-    pub(in ::fmt) fn stdout(color_choice: WriteStyle) -> Self {
-        unimplemented!()
+    pub(in ::fmt) fn stdout(_: WriteStyle) -> Self {
+        BufferWriter {
+            target: Target::Stdout,
+        }
     }
 
     pub(in ::fmt) fn buffer(&self) -> Buffer {
-        unimplemented!()
+        Buffer(Vec::new())
     }
 
     pub(in ::fmt) fn print(&self, buf: &Buffer) -> io::Result<()> {
-        unimplemented!()
+        match self.target {
+            Target::Stderr => io::stderr().write_all(&buf.0),
+            Target::Stdout => io::stdout().write_all(&buf.0),
+        }
     }
 }
 
 impl Buffer {
     pub(in ::fmt) fn clear(&mut self) {
-        unimplemented!()
+        self.0.clear();
     }
 
     pub(in ::fmt) fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
-        unimplemented!()
+        self.0.extend(buf);
+        Ok(buf.len())
     }
 
     pub(in ::fmt) fn flush(&mut self) -> io::Result<()> {
-        unimplemented!()
+        Ok(())
     }
 }

--- a/src/fmt/termcolor/shim_impl.rs
+++ b/src/fmt/termcolor/shim_impl.rs
@@ -3,7 +3,7 @@ use std::io;
 
 use ::WriteStyle;
 
-pub(in ::fmt) mod pub_use {
+pub(in ::fmt) mod pub_use_in_super {
     
 }
 

--- a/src/fmt/termcolor/shim_impl.rs
+++ b/src/fmt/termcolor/shim_impl.rs
@@ -1,0 +1,43 @@
+use std::fmt;
+use std::io;
+
+use ::WriteStyle;
+
+pub(in ::fmt) mod pub_use {
+    
+}
+
+pub(in ::fmt) struct BufferWriter {}
+pub(in ::fmt) struct Buffer {}
+
+impl BufferWriter {
+    pub(in ::fmt) fn stderr(color_choice: WriteStyle) -> Self {
+        unimplemented!()
+    }
+
+    pub(in ::fmt) fn stdout(color_choice: WriteStyle) -> Self {
+        unimplemented!()
+    }
+
+    pub(in ::fmt) fn buffer(&self) -> Buffer {
+        unimplemented!()
+    }
+
+    pub(in ::fmt) fn print(&self, buf: &Buffer) -> io::Result<()> {
+        unimplemented!()
+    }
+}
+
+impl Buffer {
+    pub(in ::fmt) fn clear(&mut self) {
+        unimplemented!()
+    }
+
+    pub(in ::fmt) fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
+        unimplemented!()
+    }
+
+    pub(in ::fmt) fn flush(&mut self) -> io::Result<()> {
+        unimplemented!()
+    }
+}

--- a/src/fmt/termcolor/shim_impl.rs
+++ b/src/fmt/termcolor/shim_impl.rs
@@ -31,8 +31,16 @@ impl BufferWriter {
 
     pub(in ::fmt) fn print(&self, buf: &Buffer) -> io::Result<()> {
         match self.target {
-            Target::Stderr => io::stderr().write_all(&buf.0),
-            Target::Stdout => io::stdout().write_all(&buf.0),
+            Target::Stderr => {
+                let stderr = io::stderr();
+                let mut stderr = stderr.lock();
+                stderr.write_all(&buf.0)
+            },
+            Target::Stdout => {
+                let stdout = io::stdout();
+                let mut stdout = stdout.lock();
+                stdout.write_all(&buf.0)
+            },
         }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -235,7 +235,7 @@ use log::{Log, LevelFilter, Record, SetLoggerError, Metadata};
 pub mod filter;
 pub mod fmt;
 
-pub use self::fmt::pub_use::*;
+pub use self::fmt::pub_use_in_super::*;
 
 /// The default name for the environment variable to read filters from.
 pub const DEFAULT_FILTER_ENV: &'static str = "RUST_LOG";

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -212,7 +212,7 @@
 #![cfg_attr(rustbuild, feature(staged_api, rustc_private))]
 #![cfg_attr(rustbuild, unstable(feature = "rustc_private", issue = "27812"))]
 
-// #![deny(missing_debug_implementations, missing_docs, warnings)]
+#![deny(missing_debug_implementations, missing_docs, warnings)]
 
 extern crate log;
 


### PR DESCRIPTION
Except for `log`.

Closes #71
Closes #72

This PR refactors the internals of the `fmt` module so we can optionally exclude dependencies and their supported features. The goal of making things optional is to improve compile times and reduce artifact sizes so rather than trying to shim the same public API we exclude swathes of API that are tied to specific dependencies when those dependencies aren't available.

By default all current dependencies are included. Since `env_logger` usually lives at the top of a dependency graph, if an application disables default features then it should be unlikely that another dependency adds them back in.

This is still in a bit of a strawman phase, there might be other approaches we'll want to consider.