### PR TITLE
update some debs for minimal-versions

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,10 +18,10 @@ status = "actively-developed"
 
 [dependencies]
 log = { version = "0.4", features = ["std"] }
-regex = { version = "1", optional = true }
+regex = { version = "1.0.3", optional = true }
 termcolor = "1"
 humantime = "1.1"
-atty = "0.2"
+atty = "0.2.5"
 
 [[test]]
 name = "regexp_filter"


### PR DESCRIPTION
This bumps the minimal acceptable versions in Cargo.toml to versions that are compatible with `-Z minimal-versions`. This is part of the process of seeing how hard this is for crates to use in preparation for getting it stabilized for use in CI, specifically upstreaming the changes required to get criterion working with it. It is easy to use if all of your dependencies support it, but much harder if trying to impose it on them.