### PR TITLE
Fix up confusing Debug impl for built Builder

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: rust
 sudo: false
 rust:
-  - 1.20.0
+  - 1.24.1
   - stable
   - beta
   - nightly

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -931,10 +931,16 @@ mod std_fmt_impls {
 
     impl fmt::Debug for Builder{
         fn fmt(&self, f: &mut fmt::Formatter)->fmt::Result {
-            f.debug_struct("Logger")
-            .field("filter", &self.filter)
-            .field("writer", &self.writer)
-            .finish()
+            if self.built {
+                f.debug_struct("Logger")
+                .field("built", &true)
+                .finish()
+            } else {
+                f.debug_struct("Logger")
+                .field("filter", &self.filter)
+                .field("writer", &self.writer)
+                .finish()
+            }
         }
     }
 }


### PR DESCRIPTION
For #108 

The debug output of the `Builder` is pretty confusing after it's already been built, because we logically move out of all of its fields, leaving them in an arbitrary state.

This just updates the debug output for a built `Builder` not to expose its fields.