### PR TITLE
Prepare for 0.6.0 release

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "env_logger"
-version = "0.5.13" # remember to update html_root_url
+version = "0.6.0" # remember to update html_root_url
 authors = ["The Rust Project Developers"]
 license = "MIT/Apache-2.0"
 readme = "README.md"

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ It must be added along with `log` to the project dependencies:
 ```toml
 [dependencies]
 log = "0.4.0"
-env_logger = "0.5.13"
+env_logger = "0.6.0"
 ```
 
 `env_logger` must be initialized as early as possible in the project. After it's initialized, you can use the `log` macros to do actual logging.
@@ -52,7 +52,7 @@ Tests can use the `env_logger` crate to see log messages generated during that t
 log = "0.4.0"
 
 [dev-dependencies]
-env_logger = { version = "0.5.13", default-features = false }
+env_logger = { version = "0.6.0", default-features = false }
 ```
 
 ```rust

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -211,7 +211,7 @@
 
 #![doc(html_logo_url = "http://www.rust-lang.org/logos/rust-logo-128x128-blk-v2.png",
        html_favicon_url = "http://www.rust-lang.org/favicon.ico",
-       html_root_url = "https://docs.rs/env_logger/0.5.13")]
+       html_root_url = "https://docs.rs/env_logger/0.6.0")]
 #![cfg_attr(test, deny(warnings))]
 
 // When compiled for the rustc compiler itself we want to make sure that this is


### PR DESCRIPTION
[Current changeset](https://github.com/sebasmagri/env_logger/compare/v0.5.13...master)

This release looks a lot like `0.5.x`, but makes a few changes that are worth calling out:

- All dependencies are optional, so the behaviour of compiling with `default-features = false` is different. You get a much slimmer, but less feature-full `env_logger`.
- The default format is explicitly not stable, so it may change with any new patch version.

It doesn't look like any major issues were raised in #103, but if anything comes up we can roll it in. There's no hurry.