### PR TITLE
Test with `-Z minimal-versions` on CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,13 +8,16 @@ rust:
 before_script:
   - pip install 'travis-cargo<0.2' --user && export PATH=$HOME/.local/bin:$PATH
 script:
+  - if [ "${MINIMAL_VERSIONS}" = "y" ]; then cargo update -Z minimal-versions; fi
   - cargo run -p ci
   - cargo run --example default
-  - if [ "${TRAVIS_RUST_VERSION}" = nightly ]; then cargo update -Z minimal-versions; fi
-  - if [ "${TRAVIS_RUST_VERSION}" = nightly ]; then cargo run -p ci; fi
-  - if [ "${TRAVIS_RUST_VERSION}" = nightly ]; then cargo run --example default; fi
 after_success:
   - travis-cargo --only nightly doc-upload
+
+matrix:
+  include:
+    - rust: nightly
+      env: MINIMAL_VERSIONS=y
 
 notifications:
   email:

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,9 @@ before_script:
 script:
   - cargo run -p ci
   - cargo run --example default
+  - if [ "${TRAVIS_RUST_VERSION}" = nightly ]; then cargo update -Z minimal-versions; fi
+  - if [ "${TRAVIS_RUST_VERSION}" = nightly ]; then cargo run -p ci; fi
+  - if [ "${TRAVIS_RUST_VERSION}" = nightly ]; then cargo run --example default; fi
 after_success:
   - travis-cargo --only nightly doc-upload
 


### PR DESCRIPTION
Just to make sure that reverse dependencies on `env_logger` won't break on `-Z minimal-versions` as well.