### PR TITLE
Fix path for rust-lang favicon

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -209,8 +209,8 @@
 //! [`Env`]: struct.Env.html
 //! [`fmt`]: fmt/index.html
 
-#![doc(html_logo_url = "http://www.rust-lang.org/logos/rust-logo-128x128-blk-v2.png",
-       html_favicon_url = "http://www.rust-lang.org/favicon.ico",
+#![doc(html_logo_url = "https://www.rust-lang.org/logos/rust-logo-128x128-blk-v2.png",
+       html_favicon_url = "https://www.rust-lang.org/static/images/favicon.ico",
        html_root_url = "https://docs.rs/env_logger/0.6.0")]
 #![cfg_attr(test, deny(warnings))]
 


### PR DESCRIPTION
This commit sorts out a couple of issues:
- fix broken path to rust-lang favicon
- use https for rust-lang addresses to stop content mixing when visiting over https

Both issues can be seen in the screenshot of my chrome console below:
<img width="492" alt="screenshot 2018-12-18 at 13 40 43" src="https://user-images.githubusercontent.com/652790/50157999-c992c800-02ca-11e9-89c4-4c3fe91993be.png">
