### PR TITLE
Support capturing for cargo test

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ Tests can use the `env_logger` crate to see log messages generated during that t
 log = "0.4.0"
 
 [dev-dependencies]
-env_logger = { version = "0.6.0", default-features = false }
+env_logger = "0.6.0"
 ```
 
 ```rust
@@ -69,16 +69,22 @@ mod tests {
     use super::*;
     extern crate env_logger;
 
+    fn init() {
+        let _ = env_logger::builder().is_test(true).try_init();
+    }
+
     #[test]
     fn it_adds_one() {
-        let _ = env_logger::try_init();
+        init();
+
         info!("can log from the test too");
         assert_eq!(3, add_one(2));
     }
 
     #[test]
     fn it_handles_negative_numbers() {
-        let _ = env_logger::try_init();
+        init();
+
         info!("logging from another test");
         assert_eq!(-7, add_one(-8));
     }

--- a/src/fmt/writer/mod.rs
+++ b/src/fmt/writer/mod.rs
@@ -106,11 +106,6 @@ impl Builder {
         self
     }
 
-    /// Parses a test flag string.
-    pub(crate) fn parse_is_test(&mut self, is_test: &str) -> &mut Self {
-        self.is_test(parse_is_test(is_test))
-    }
-
     /// Whether or not to capture logs for `cargo test`.
     pub(crate) fn is_test(&mut self, is_test: bool) -> &mut Self {
         self.is_test = is_test;
@@ -178,13 +173,6 @@ fn parse_write_style(spec: &str) -> WriteStyle {
     }
 }
 
-fn parse_is_test(spec: &str) -> bool {
-    match spec {
-        "1" => true,
-        _ => false,
-    }
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -214,16 +202,5 @@ mod tests {
         for input in inputs {
             assert_eq!(WriteStyle::Auto, parse_write_style(input));
         }
-    }
-
-    #[test]
-    fn parse_is_test_valid() {
-        assert!(parse_is_test("1"));
-        assert!(!parse_is_test("0"));
-    }
-
-    #[test]
-    fn parse_is_test_invalid() {
-        assert!(!parse_is_test("pls do"));
     }
 }

--- a/src/fmt/writer/termcolor/shim_impl.rs
+++ b/src/fmt/writer/termcolor/shim_impl.rs
@@ -13,13 +13,13 @@ pub(in ::fmt::writer) struct BufferWriter {
 pub(in ::fmt) struct Buffer(Vec<u8>);
 
 impl BufferWriter {
-    pub(in ::fmt::writer) fn stderr(_: WriteStyle) -> Self {
+    pub(in ::fmt::writer) fn stderr(_is_test: bool, _write_style: WriteStyle) -> Self {
         BufferWriter {
             target: Target::Stderr,
         }
     }
 
-    pub(in ::fmt::writer) fn stdout(_: WriteStyle) -> Self {
+    pub(in ::fmt::writer) fn stdout(_is_test: bool, _write_style: WriteStyle) -> Self {
         BufferWriter {
             target: Target::Stdout,
         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -164,10 +164,8 @@
 //! }
 //! ```
 //! 
-//! Enabling test capturing comes at the expense of color and other style support.
-//! 
-//! Test support can also be enabled by setting the `RUST_LOG_TEST` environment variable
-//! to `1`.
+//! Enabling test capturing comes at the expense of color and other style support
+//! and may have performance implications.
 //!
 //! ## Disabling colors
 //!
@@ -278,10 +276,6 @@ pub const DEFAULT_FILTER_ENV: &'static str = "RUST_LOG";
 /// The default name for the environment variable to read style preferences from.
 pub const DEFAULT_WRITE_STYLE_ENV: &'static str = "RUST_LOG_STYLE";
 
-/// The default name for the environment variable to read whether the
-/// logger will be used in unit tests from.
-pub const DEFAULT_IS_TEST_ENV: &'static str = "RUST_LOG_TEST";
-
 /// Set of environment variables to configure from.
 ///
 /// # Default environment variables
@@ -296,7 +290,6 @@ pub const DEFAULT_IS_TEST_ENV: &'static str = "RUST_LOG_TEST";
 pub struct Env<'a> {
     filter: Var<'a>,
     write_style: Var<'a>,
-    is_test: Var<'a>,
 }
 
 #[derive(Debug)]
@@ -441,10 +434,6 @@ impl Builder {
 
         if let Some(s) = env.get_write_style() {
             builder.parse_write_style(&s);
-        }
-
-        if let Some(s) = env.get_is_test() {
-            builder.parse_is_test(&s);
         }
 
         builder
@@ -685,15 +674,6 @@ impl Builder {
     /// capture log records rather than printing them to the terminal directly.
     pub fn is_test(&mut self, is_test: bool) -> &mut Self {
         self.writer.is_test(is_test);
-        self
-    }
-
-    /// Parses whether or not the logger will be used in unit tests in the same 
-    /// form as the `RUST_LOG_TEST` environment variable.
-    ///
-    /// See the module documentation for more details.
-    pub fn parse_is_test(&mut self, is_test: &str) -> &mut Self {
-        self.writer.parse_is_test(is_test);
         self
     }
 
@@ -958,48 +938,6 @@ impl<'a> Env<'a> {
     fn get_write_style(&self) -> Option<String> {
         self.write_style.get()
     }
-
-    /// Specify an environment variable to read whether the environment
-    /// is a testing framework.
-    pub fn is_test<E>(mut self, is_test_env: E) -> Self
-    where
-        E: Into<Cow<'a, str>>
-    {
-        self.is_test = Var::new(is_test_env);
-
-        self
-    }
-
-    /// Specify an environment variable to read whether the environment
-    /// is a testing framework.
-    ///
-    /// If the variable is not set, the default value will be used.
-    pub fn is_test_or<E, V>(mut self, is_test_env: E, default: V) -> Self
-        where
-            E: Into<Cow<'a, str>>,
-            V: Into<Cow<'a, str>>,
-    {
-        self.is_test = Var::new_with_default(is_test_env, default);
-
-        self
-    }
-
-    /// Use the default environment variable to read whether the environment
-    /// is a testing framework.
-    ///
-    /// If the variable is not set, the default value will be used.
-    pub fn default_is_test_or<V>(mut self, default: V) -> Self
-        where
-            V: Into<Cow<'a, str>>,
-    {
-        self.is_test = Var::new_with_default(DEFAULT_IS_TEST_ENV, default);
-
-        self
-    }
-
-    fn get_is_test(&self) -> Option<String> {
-        self.is_test.get()
-    }
 }
 
 impl<'a> Var<'a> {
@@ -1047,7 +985,6 @@ impl<'a> Default for Env<'a> {
         Env {
             filter: Var::new(DEFAULT_FILTER_ENV),
             write_style: Var::new(DEFAULT_WRITE_STYLE_ENV),
-            is_test: Var::new(DEFAULT_IS_TEST_ENV),
         }
     }
 }

--- a/tests/init-twice-retains-filter.rs
+++ b/tests/init-twice-retains-filter.rs
@@ -15,7 +15,7 @@ fn main() {
         // Init again using a different max level
         // This shouldn't clobber the level that was previously set
         env_logger::Builder::new()
-            .parse("info")
+            .parse_filters("info")
             .try_init()
             .unwrap_err();
 


### PR DESCRIPTION
Closes #107 

Adds an `is_test` method to the `Builder` that can be used to force the logger to output using the `print` or `eprint` macros instead of through `termcolor` directly. Using a builder method instead of features guarantees no matter what your `env_logger` configuration, you'll be able to make `cargo test` capture logs. `is_test` is slower than using `termcolor`.

I've also introduced some convenient crate functions to get a `Builder`:

- `env_logger::builder()` is like `env_logger::Builder::from_default_env()`
- `env_logger::from_env(e)` is like `env_logger::Builder::from_env(e)`