### PR TITLE
Add some more examples for configuring env_logger

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,8 @@ $ RUST_LOG=info ./main
 [2018-11-03T06:09:06Z INFO  default] starting up
 ```
 
+`env_logger` can be configured in other ways besides an environment variable. See [the examples](tree/master/examples) for more approaches.
+
 ### In tests
 
 Tests can use the `env_logger` crate to see log messages generated during that test:

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ $ RUST_LOG=info ./main
 [2018-11-03T06:09:06Z INFO  default] starting up
 ```
 
-`env_logger` can be configured in other ways besides an environment variable. See [the examples](tree/master/examples) for more approaches.
+`env_logger` can be configured in other ways besides an environment variable. See [the examples](https://github.com/sebasmagri/env_logger/tree/master/examples) for more approaches.
 
 ### In tests
 

--- a/examples/default.rs
+++ b/examples/default.rs
@@ -22,6 +22,9 @@ extern crate env_logger;
 use env_logger::Env;
 
 fn main() {
+    // The `Env` lets us tweak what the environment
+    // variables to read are and what the default
+    // value is if they're missing
     let env = Env::default()
         .filter_or("MY_LOG_LEVEL", "trace")
         .write_style_or("MY_LOG_STYLE", "always");

--- a/examples/filters_from_code.rs
+++ b/examples/filters_from_code.rs
@@ -1,0 +1,21 @@
+/*!
+Specify logging filters in code instead of using an environment variable.
+*/
+
+#[macro_use]
+extern crate log;
+extern crate env_logger;
+
+use env_logger::Env;
+
+fn main() {
+    env_logger::builder()
+        .filter_level(log::LevelFilter::Trace)
+        .init();
+
+    trace!("some trace log");
+    debug!("some debug log");
+    info!("some information log");
+    warn!("some warning log");
+    error!("some error log");
+}


### PR DESCRIPTION
It looks like a lot of folks are trying to set the `RUST_LOG` environment variable directly when configuring `env_logger`'s filters. We don't actually need to do this anymore, we can use the `Env` type or filters from code instead.

This PR just adds a link pointing to our examples and an example of using a builder instead of an environment variable.