### PR TITLE
Indentation for multiline log messages

### DIFF
--- a/src/fmt/humantime/extern_impl.rs
+++ b/src/fmt/humantime/extern_impl.rs
@@ -46,13 +46,12 @@ impl Formatter {
 /// [RFC3339]: https://www.ietf.org/rfc/rfc3339.txt
 /// [`Display`]: https://doc.rust-lang.org/stable/std/fmt/trait.Display.html
 /// [`Formatter`]: struct.Formatter.html
-#[derive(Clone, Copy)]
 pub struct Timestamp(SystemTime);
 
 /// An [RFC3339] formatted timestamp with nanos.
 ///
 /// [RFC3339]: https://www.ietf.org/rfc/rfc3339.txt
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug)]
 pub struct PreciseTimestamp(SystemTime);
 
 impl fmt::Debug for Timestamp {

--- a/src/fmt/humantime/extern_impl.rs
+++ b/src/fmt/humantime/extern_impl.rs
@@ -46,12 +46,13 @@ impl Formatter {
 /// [RFC3339]: https://www.ietf.org/rfc/rfc3339.txt
 /// [`Display`]: https://doc.rust-lang.org/stable/std/fmt/trait.Display.html
 /// [`Formatter`]: struct.Formatter.html
+#[derive(Clone, Copy)]
 pub struct Timestamp(SystemTime);
 
 /// An [RFC3339] formatted timestamp with nanos.
 ///
 /// [RFC3339]: https://www.ietf.org/rfc/rfc3339.txt
-#[derive(Debug)]
+#[derive(Debug, Clone, Copy)]
 pub struct PreciseTimestamp(SystemTime);
 
 impl fmt::Debug for Timestamp {

--- a/src/fmt/mod.rs
+++ b/src/fmt/mod.rs
@@ -310,8 +310,7 @@ impl<'a> DefaultFormat<'a> {
                         let mut first = true;
                         for chunk in buf.split(|&x| x == b'\n') {
                             if !first {
-                                let bar = self.fmt.subtle_style("|");
-                                write!(self.fmt.buf, "\n{:width$}{} ", "", bar, width = self.indent_count)?;
+                                write!(self.fmt.buf, "\n{:width$}", "", width = self.indent_count)?;
                             }
                             self.fmt.buf.write_all(chunk)?;
                             first = false;
@@ -426,7 +425,7 @@ mod tests {
             buf: &mut f,
         });
 
-        assert_eq!("[INFO  test::path] log\n    | message\n", written);
+        assert_eq!("[INFO  test::path] log\n    message\n", written);
     }
 
     #[test]
@@ -447,7 +446,7 @@ mod tests {
             buf: &mut f,
         });
 
-        assert_eq!("[INFO  test::path] log\n| message\n", written);
+        assert_eq!("[INFO  test::path] log\nmessage\n", written);
     }
 
     #[test]
@@ -468,6 +467,6 @@ mod tests {
             buf: &mut f,
         });
 
-        assert_eq!("log\n    | message\n", written);
+        assert_eq!("log\n    message\n", written);
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -528,6 +528,12 @@ impl Builder {
         self
     }
 
+    /// Configures the indentation policy for multiline log records.
+    pub fn default_format_indent(&mut self, indent: fmt::Indent) -> &mut Self {
+        self.format.default_format_indent = indent;
+        self
+    }
+
     /// Adds a directive to the filter for a specific module.
     ///
     /// # Examples

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -528,6 +528,13 @@ impl Builder {
         self
     }
 
+    /// Configures the amount of spaces to use to indent multiline log records.
+    /// A value of `None` disables any kind of indentation.
+    pub fn default_format_indent(&mut self, indent: Option<usize>) -> &mut Self {
+        self.format.default_format_indent = indent;
+        self
+    }
+
     /// Adds a directive to the filter for a specific module.
     ///
     /// # Examples

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -528,12 +528,6 @@ impl Builder {
         self
     }
 
-    /// Configures the indentation policy for multiline log records.
-    pub fn default_format_indent(&mut self, indent: fmt::Indent) -> &mut Self {
-        self.format.default_format_indent = indent;
-        self
-    }
-
     /// Adds a directive to the filter for a specific module.
     ///
     /// # Examples


### PR DESCRIPTION
The default formatter does not handle multiline messages at all: if a log entry contains a newline,
the second line gets behind the header, which can appear a bit strange.

This PR implements 4 different strategies to handle them, represented by the new enum `fmt::Indent`:

- `Indent::None`: this is the current and default behaviour.
- `Indent::Spaces(usize)`: indent next lines of a fixed amount of spaces.
- `Indent::Auto`: indent the next lines so that they are all aligned to the header of the first line.
- `Indent::RepeatHeader`: repeat the header for each line.

The idea is to expose the indentation as a setting of the default formatter (by adding a new function `default_format_indent` to the `Builder`), so that the user can choose his preferred style. The default setting is obviously `Indent::None` for backward compatibility.

Thank you for your time!

# Example

This is a screenshot of running the following program with different indentation settings in the following order: `None` (the default), `Spaces(4)`, `Auto`, `RepeatHeader`.

```rust
#[macro_use]
extern crate log;
extern crate env_logger;

use log::LevelFilter;
use env_logger::fmt::Indent;

fn main() {
    env_logger::Builder::from_default_env()
        .filter_level(LevelFilter::Info)
        .default_format_indent(Indent::Auto)
        .init();

    info!("First line\nSecond line\nThird line");
}
```

![Indent test](https://user-images.githubusercontent.com/852259/58672873-3a91dd80-8349-11e9-8e39-df9bdcecde54.png)
