### PR TITLE
Fix up the build on nightly compilers

### DIFF
--- a/examples/filters_from_code.rs
+++ b/examples/filters_from_code.rs
@@ -6,8 +6,6 @@ Specify logging filters in code instead of using an environment variable.
 extern crate log;
 extern crate env_logger;
 
-use env_logger::Env;
-
 fn main() {
     env_logger::builder()
         .filter_level(log::LevelFilter::Trace)

--- a/src/fmt/mod.rs
+++ b/src/fmt/mod.rs
@@ -117,6 +117,7 @@ pub(crate) struct Builder {
     pub default_format_timestamp_nanos: bool,
     pub default_format_module_path: bool,
     pub default_format_level: bool,
+    #[allow(unknown_lints, bare_trait_objects)]
     pub custom_format: Option<Box<Fn(&mut Formatter, &Record) -> io::Result<()> + Sync + Send>>,
     built: bool,
 }
@@ -140,6 +141,7 @@ impl Builder {
     /// If the `custom_format` is `Some`, then any `default_format` switches are ignored.
     /// If the `custom_format` is `None`, then a default format is returned.
     /// Any `default_format` switches set to `false` won't be written by the format.
+    #[allow(unknown_lints, bare_trait_objects)]
     pub fn build(&mut self) -> Box<Fn(&mut Formatter, &Record) -> io::Result<()> + Sync + Send> {
         assert!(!self.built, "attempt to re-use consumed builder");
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -322,6 +322,7 @@ struct Var<'a> {
 pub struct Logger {
     writer: Writer,
     filter: Filter,
+    #[allow(unknown_lints, bare_trait_objects)]
     format: Box<Fn(&mut Formatter, &Record) -> io::Result<()> + Sync + Send>,
 }
 


### PR DESCRIPTION
A new lint on `nightly` requires trait objects use the `dyn` keyword. This isn't recognized by our minimum supported `rustc` version (`1.24.1`) so we allow the bare trait objects where they're used.