### PR TITLE
Add more timestamp precisions

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ members = [
 log = { version = "0.4", features = ["std"] }
 regex = { version = "1.0.3", optional = true }
 termcolor = { version = "1.0.2", optional = true }
-humantime = { version = "1.1", optional = true }
+humantime = { version = "1.3", optional = true }
 atty = { version = "0.2.5", optional = true }
 
 [[test]]

--- a/src/fmt/humantime/extern_impl.rs
+++ b/src/fmt/humantime/extern_impl.rs
@@ -1,9 +1,12 @@
 use std::fmt;
 use std::time::SystemTime;
 
-use humantime::{format_rfc3339_nanos, format_rfc3339_seconds};
+use humantime::{
+    format_rfc3339_micros, format_rfc3339_millis,
+    format_rfc3339_nanos, format_rfc3339_seconds,
+};
 
-use ::fmt::Formatter;
+use ::fmt::{Formatter, TimestampPrecision};
 
 pub(in ::fmt) mod glob {
     pub use super::*;
@@ -30,10 +33,50 @@ impl Formatter {
     ///
     /// [`Timestamp`]: struct.Timestamp.html
     pub fn timestamp(&self) -> Timestamp {
-        Timestamp(SystemTime::now())
+        Timestamp {
+            time: SystemTime::now(),
+            precision: TimestampPrecision::Seconds,
+        }
+    }
+
+    /// Get a [`Timestamp`] for the current date and time in UTC with full
+    /// second precision.
+    pub fn timestamp_seconds(&self) -> Timestamp {
+        Timestamp {
+            time: SystemTime::now(),
+            precision: TimestampPrecision::Seconds,
+        }
+    }
+
+    /// Get a [`Timestamp`] for the current date and time in UTC with
+    /// millisecond precision.
+    pub fn timestamp_millis(&self) -> Timestamp {
+        Timestamp {
+            time: SystemTime::now(),
+            precision: TimestampPrecision::Millis,
+        }
+    }
+
+    /// Get a [`Timestamp`] for the current date and time in UTC with
+    /// microsecond precision.
+    pub fn timestamp_micros(&self) -> Timestamp {
+        Timestamp {
+            time: SystemTime::now(),
+            precision: TimestampPrecision::Micros,
+        }
+    }
+
+    /// Get a [`Timestamp`] for the current date and time in UTC with
+    /// nanosecond precision.
+    pub fn timestamp_nanos(&self) -> Timestamp {
+        Timestamp {
+            time: SystemTime::now(),
+            precision: TimestampPrecision::Nanos,
+        }
     }
 
     /// Get a [`PreciseTimestamp`] for the current date and time in UTC with nanos.
+    #[deprecated = "Use timestamp_nanos() instead"]
     pub fn precise_timestamp(&self) -> PreciseTimestamp {
         PreciseTimestamp(SystemTime::now())
     }
@@ -46,7 +89,10 @@ impl Formatter {
 /// [RFC3339]: https://www.ietf.org/rfc/rfc3339.txt
 /// [`Display`]: https://doc.rust-lang.org/stable/std/fmt/trait.Display.html
 /// [`Formatter`]: struct.Formatter.html
-pub struct Timestamp(SystemTime);
+pub struct Timestamp {
+    time: SystemTime,
+    precision: TimestampPrecision,
+}
 
 /// An [RFC3339] formatted timestamp with nanos.
 ///
@@ -72,8 +118,15 @@ impl fmt::Debug for Timestamp {
 }
 
 impl fmt::Display for Timestamp {
-    fn fmt(&self, f: &mut fmt::Formatter)->fmt::Result {
-        format_rfc3339_seconds(self.0).fmt(f)
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        let formatter = match self.precision {
+            TimestampPrecision::Seconds => format_rfc3339_seconds,
+            TimestampPrecision::Millis => format_rfc3339_millis,
+            TimestampPrecision::Micros => format_rfc3339_micros,
+            TimestampPrecision::Nanos => format_rfc3339_nanos,
+        };
+
+        formatter(self.time).fmt(f)
     }
 }
 

--- a/src/fmt/mod.rs
+++ b/src/fmt/mod.rs
@@ -277,6 +277,9 @@ impl<'a> DefaultFormat<'a> {
         }
         #[cfg(not(feature = "humantime"))]
         {
+            // Trick the compiler to think we have used self.timestamp
+            // Workaround for "field is never used: `timestamp`" compiler nag.
+            let _ = self.timestamp;
             Ok(())
         }
     }


### PR DESCRIPTION
This PR adds two more timestamp precisions: milliseconds and microseconds. 

I sprinkled some `#[deprecated]` tags around for things I consider could be removed in the future since the same functionality can be achieved in other way.

This probably still have sharp corners to work on.

Fixes #122