### PR TITLE
Bump minimum rust version up to 1.28.0.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: rust
 sudo: false
 rust:
-  - 1.24.1
+  - 1.28.0
   - stable
   - beta
   - nightly


### PR DESCRIPTION
This is the oldest version regex 1.3 crate supports. And this should fix the failing TravisCI tests.