### PR TITLE
Update to 2018 edition

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: rust
 sudo: false
 rust:
-  - 1.28.0
+  - 1.31.0
   - stable
   - beta
   - nightly

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,6 @@
 [package]
 name = "env_logger"
+edition = "2018"
 version = "0.6.2" # remember to update html_root_url
 authors = ["The Rust Project Developers"]
 license = "MIT/Apache-2.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ members = [
 ]
 
 [dependencies]
-log = { version = "0.4", features = ["std"] }
+log = { version = "0.4.8", features = ["std"] }
 regex = { version = "1.0.3", optional = true }
 termcolor = { version = "1.0.2", optional = true }
 humantime = { version = "1.3", optional = true }

--- a/README.md
+++ b/README.md
@@ -24,7 +24,6 @@ env_logger = "0.6.2"
 ```rust
 #[macro_use]
 extern crate log;
-extern crate env_logger;
 
 fn main() {
     env_logger::init();
@@ -69,7 +68,6 @@ fn add_one(num: i32) -> i32 {
 #[cfg(test)]
 mod tests {
     use super::*;
-    extern crate env_logger;
 
     fn init() {
         let _ = env_logger::builder().is_test(true).try_init();

--- a/ci/Cargo.toml
+++ b/ci/Cargo.toml
@@ -1,5 +1,6 @@
 [package]
 name = "ci"
+edition = "2018"
 version = "0.0.0"
 authors = ["The Rust Project Developers"]
 publish = false

--- a/ci/src/main.rs
+++ b/ci/src/main.rs
@@ -1,13 +1,8 @@
-mod task;
 mod permute;
+mod task;
 
 fn main() {
-    let features = [
-        "termcolor",
-        "humantime",
-        "atty",
-        "regex",
-    ];
+    let features = ["termcolor", "humantime", "atty", "regex"];
 
     // Run a default build
     if !task::test(Default::default()) {
@@ -25,12 +20,13 @@ fn main() {
     // Run a set of permutations
     let failed = permute::all(&features)
         .into_iter()
-        .filter(|features| 
+        .filter(|features| {
             !task::test(task::TestArgs {
                 features: features.clone(),
                 default_features: false,
                 lib_only: true,
-            }))
+            })
+        })
         .collect::<Vec<_>>();
 
     if failed.len() > 0 {

--- a/ci/src/permute.rs
+++ b/ci/src/permute.rs
@@ -1,6 +1,9 @@
 use std::collections::BTreeSet;
 
-pub fn all<T>(input: &[T]) -> BTreeSet<BTreeSet<T>> where T: Ord + Eq + Clone {
+pub fn all<T>(input: &[T]) -> BTreeSet<BTreeSet<T>>
+where
+    T: Ord + Eq + Clone,
+{
     let mut permutations = BTreeSet::new();
 
     if input.len() == 0 {

--- a/ci/src/task.rs
+++ b/ci/src/task.rs
@@ -1,8 +1,5 @@
 use std::collections::BTreeSet;
-use std::process::{
-    Command,
-    Stdio,
-};
+use std::process::{Command, Stdio};
 
 pub type Feature = &'static str;
 
@@ -45,7 +42,7 @@ pub fn test(args: TestArgs) -> bool {
     let features = args.features_string();
 
     let mut command = Command::new("cargo");
-        
+
     command
         .stdout(Stdio::inherit())
         .stderr(Stdio::inherit())
@@ -65,13 +62,14 @@ pub fn test(args: TestArgs) -> bool {
     }
 
     println!("running {:?}", command);
-    
-    let status = command
-        .status()
-        .expect("Failed to execute command");
+
+    let status = command.status().expect("Failed to execute command");
 
     if !status.success() {
-        eprintln!("test execution failed for features: {}", features.as_ref().map(AsRef::as_ref).unwrap_or(""));
+        eprintln!(
+            "test execution failed for features: {}",
+            features.as_ref().map(AsRef::as_ref).unwrap_or("")
+        );
         false
     } else {
         true

--- a/examples/custom_default_format.rs
+++ b/examples/custom_default_format.rs
@@ -19,9 +19,8 @@ If you want to control the logging output completely, see the `custom_logger` ex
 
 #[macro_use]
 extern crate log;
-extern crate env_logger;
 
-use env_logger::{Env, Builder};
+use env_logger::{Builder, Env};
 
 fn init_logger() {
     let env = Env::default()
@@ -30,9 +29,7 @@ fn init_logger() {
 
     let mut builder = Builder::from_env(env);
 
-    builder
-        .default_format_level(false)
-        .default_format_timestamp_nanos();
+    builder.format_level(false).format_timestamp_nanos();
 
     builder.init();
 }

--- a/examples/custom_default_format.rs
+++ b/examples/custom_default_format.rs
@@ -32,7 +32,7 @@ fn init_logger() {
 
     builder
         .default_format_level(false)
-        .default_format_timestamp_nanos(true);
+        .default_format_timestamp_nanos();
 
     builder.init();
 }

--- a/examples/custom_format.rs
+++ b/examples/custom_format.rs
@@ -17,38 +17,37 @@ $ export MY_LOG_STYLE=never
 If you want to control the logging output completely, see the `custom_logger` example.
 */
 
-#[macro_use]
-extern crate log;
-extern crate env_logger;
-
-use std::io::Write;
-
-use env_logger::{Env, Builder, fmt};
-
-fn init_logger() {
-    let env = Env::default()
-        .filter("MY_LOG_LEVEL")
-        .write_style("MY_LOG_STYLE");
-
-    let mut builder = Builder::from_env(env);
-
-    // Use a different format for writing log records
-    // The colors are only available when the `termcolor` dependency is (which it is by default)
-    #[cfg(feature = "termcolor")]
-    builder.format(|buf, record| {
-        let mut style = buf.style();
-        style.set_bg(fmt::Color::Yellow).set_bold(true);
-
-        let timestamp = buf.timestamp();
-
-        writeln!(buf, "My formatted log ({}): {}", timestamp, style.value(record.args()))
-    });
-
-    builder.init();
-}
-
+#[cfg(all(feature = "termcolor", feature = "humantime"))]
 fn main() {
+    use env_logger::{fmt, Builder, Env};
+    use std::io::Write;
+
+    fn init_logger() {
+        let env = Env::default()
+            .filter("MY_LOG_LEVEL")
+            .write_style("MY_LOG_STYLE");
+
+        Builder::from_env(env)
+            .format(|buf, record| {
+                let mut style = buf.style();
+                style.set_bg(fmt::Color::Yellow).set_bold(true);
+
+                let timestamp = buf.timestamp();
+
+                writeln!(
+                    buf,
+                    "My formatted log ({}): {}",
+                    timestamp,
+                    style.value(record.args())
+                )
+            })
+            .init();
+    }
+
     init_logger();
 
-    info!("a log from `MyLogger`");
+    log::info!("a log from `MyLogger`");
 }
+
+#[cfg(not(all(feature = "termcolor", feature = "humantime")))]
+fn main() {}

--- a/examples/custom_logger.rs
+++ b/examples/custom_logger.rs
@@ -12,12 +12,12 @@ If you only want to change the way logs are formatted, look at the `custom_forma
 
 #[macro_use]
 extern crate log;
-extern crate env_logger;
+
 use env_logger::filter::Filter;
 use log::{Log, Metadata, Record, SetLoggerError};
 
 struct MyLogger {
-    inner: Filter
+    inner: Filter,
 }
 
 impl MyLogger {
@@ -26,7 +26,7 @@ impl MyLogger {
         let mut builder = Builder::from_env("MY_LOG_LEVEL");
 
         MyLogger {
-            inner: builder.build()
+            inner: builder.build(),
         }
     }
 
@@ -50,7 +50,7 @@ impl Log for MyLogger {
         }
     }
 
-    fn flush(&self) { }
+    fn flush(&self) {}
 }
 
 fn main() {

--- a/examples/default.rs
+++ b/examples/default.rs
@@ -17,7 +17,6 @@ $ export MY_LOG_STYLE=never
 
 #[macro_use]
 extern crate log;
-extern crate env_logger;
 
 use env_logger::Env;
 

--- a/examples/direct_logger.rs
+++ b/examples/direct_logger.rs
@@ -4,9 +4,6 @@ Using `env_logger::Logger` and the `log::Log` trait directly.
 This example doesn't rely on environment variables, or having a static logger installed.
 */
 
-extern crate log;
-extern crate env_logger;
-
 fn record() -> log::Record<'static> {
     let error_metadata = log::MetadataBuilder::new()
         .target("myApp")
@@ -34,7 +31,7 @@ fn main() {
         .filter(None, log::LevelFilter::Error)
         .write_style(env_logger::WriteStyle::Never)
         .build();
-    
+
     stylish_logger.log(&record());
     unstylish_logger.log(&record());
 }

--- a/examples/filters_from_code.rs
+++ b/examples/filters_from_code.rs
@@ -4,7 +4,6 @@ Specify logging filters in code instead of using an environment variable.
 
 #[macro_use]
 extern crate log;
-extern crate env_logger;
 
 fn main() {
     env_logger::builder()

--- a/src/filter/mod.rs
+++ b/src/filter/mod.rs
@@ -1,15 +1,15 @@
 //! Filtering for log records.
-//! 
+//!
 //! This module contains the log filtering used by `env_logger` to match records.
-//! You can use the `Filter` type in your own logger implementation to use the same 
-//! filter parsing and matching as `env_logger`. For more details about the format 
+//! You can use the `Filter` type in your own logger implementation to use the same
+//! filter parsing and matching as `env_logger`. For more details about the format
 //! for directive strings see [Enabling Logging].
-//! 
+//!
 //! ## Using `env_logger` in your own logger
 //!
 //! You can use `env_logger`'s filtering functionality with your own logger.
-//! Call [`Builder::parse`] to parse directives from a string when constructing 
-//! your logger. Call [`Filter::matches`] to check whether a record should be 
+//! Call [`Builder::parse`] to parse directives from a string when constructing
+//! your logger. Call [`Filter::matches`] to check whether a record should be
 //! logged based on the parsed filters when log records are received.
 //!
 //! ```
@@ -54,15 +54,15 @@
 //! }
 //! # fn main() {}
 //! ```
-//! 
+//!
 //! [Enabling Logging]: ../index.html#enabling-logging
 //! [`Builder::parse`]: struct.Builder.html#method.parse
 //! [`Filter::matches`]: struct.Filter.html#method.matches
 
+use log::{Level, LevelFilter, Metadata, Record};
 use std::env;
-use std::mem;
 use std::fmt;
-use log::{Level, LevelFilter, Record, Metadata};
+use std::mem;
 
 #[cfg(feature = "regex")]
 #[path = "regex.rs"]
@@ -73,11 +73,11 @@ mod inner;
 mod inner;
 
 /// A log filter.
-/// 
+///
 /// This struct can be used to determine whether or not a log record
 /// should be written to the output.
 /// Use the [`Builder`] type to parse and construct a `Filter`.
-/// 
+///
 /// [`Builder`]: struct.Builder.html
 pub struct Filter {
     directives: Vec<Directive>,
@@ -85,10 +85,10 @@ pub struct Filter {
 }
 
 /// A builder for a log filter.
-/// 
+///
 /// It can be used to parse a set of directives from a string before building
 /// a [`Filter`] instance.
-/// 
+///
 /// ## Example
 ///
 /// ```
@@ -111,7 +111,7 @@ pub struct Filter {
 ///     let filter = builder.build();
 /// }
 /// ```
-/// 
+///
 /// [`Filter`]: struct.Filter.html
 pub struct Builder {
     directives: Vec<Directive>,
@@ -148,7 +148,8 @@ impl Filter {
     /// }
     /// ```
     pub fn filter(&self) -> LevelFilter {
-        self.directives.iter()
+        self.directives
+            .iter()
             .map(|d| d.level)
             .max()
             .unwrap_or(LevelFilter::Off)
@@ -213,9 +214,7 @@ impl Builder {
     ///
     /// The given module (if any) will log at most the specified level provided.
     /// If no module is provided then the filter will apply to all log messages.
-    pub fn filter(&mut self,
-                  module: Option<&str>,
-                  level: LevelFilter) -> &mut Self {
+    pub fn filter(&mut self, module: Option<&str>, level: LevelFilter) -> &mut Self {
         self.directives.push(Directive {
             name: module.map(|s| s.to_string()),
             level,
@@ -226,7 +225,7 @@ impl Builder {
     /// Parses the directives string.
     ///
     /// See the [Enabling Logging] section for more details.
-    /// 
+    ///
     /// [Enabling Logging]: ../index.html#enabling-logging
     pub fn parse(&mut self, filters: &str) -> &mut Self {
         let (directives, filter) = parse_spec(filters);
@@ -274,7 +273,7 @@ impl Default for Builder {
 }
 
 impl fmt::Debug for Filter {
-    fn fmt(&self, f: &mut fmt::Formatter)->fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         f.debug_struct("Filter")
             .field("filter", &self.filter)
             .field("directives", &self.directives)
@@ -283,16 +282,14 @@ impl fmt::Debug for Filter {
 }
 
 impl fmt::Debug for Builder {
-    fn fmt(&self, f: &mut fmt::Formatter)->fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         if self.built {
-            f.debug_struct("Filter")
-            .field("built", &true)
-            .finish()
+            f.debug_struct("Filter").field("built", &true).finish()
         } else {
             f.debug_struct("Filter")
-            .field("filter", &self.filter)
-            .field("directives", &self.directives)
-            .finish()
+                .field("filter", &self.filter)
+                .field("directives", &self.directives)
+                .finish()
         }
     }
 }
@@ -306,68 +303,75 @@ fn parse_spec(spec: &str) -> (Vec<Directive>, Option<inner::Filter>) {
     let mods = parts.next();
     let filter = parts.next();
     if parts.next().is_some() {
-        eprintln!("warning: invalid logging spec '{}', \
-                  ignoring it (too many '/'s)", spec);
+        eprintln!(
+            "warning: invalid logging spec '{}', \
+             ignoring it (too many '/'s)",
+            spec
+        );
         return (dirs, None);
     }
-    mods.map(|m| { for s in m.split(',') {
-        if s.len() == 0 { continue }
-        let mut parts = s.split('=');
-        let (log_level, name) = match (parts.next(), parts.next().map(|s| s.trim()), parts.next()) {
-            (Some(part0), None, None) => {
-                // if the single argument is a log-level string or number,
-                // treat that as a global fallback
-                match part0.parse() {
-                    Ok(num) => (num, None),
-                    Err(_) => (LevelFilter::max(), Some(part0)),
-                }
+    mods.map(|m| {
+        for s in m.split(',') {
+            if s.len() == 0 {
+                continue;
             }
-            (Some(part0), Some(""), None) => (LevelFilter::max(), Some(part0)),
-            (Some(part0), Some(part1), None) => {
-                match part1.parse() {
-                    Ok(num) => (num, Some(part0)),
-                    _ => {
-                        eprintln!("warning: invalid logging spec '{}', \
-                                  ignoring it", part1);
-                        continue
+            let mut parts = s.split('=');
+            let (log_level, name) =
+                match (parts.next(), parts.next().map(|s| s.trim()), parts.next()) {
+                    (Some(part0), None, None) => {
+                        // if the single argument is a log-level string or number,
+                        // treat that as a global fallback
+                        match part0.parse() {
+                            Ok(num) => (num, None),
+                            Err(_) => (LevelFilter::max(), Some(part0)),
+                        }
                     }
-                }
-            },
-            _ => {
-                eprintln!("warning: invalid logging spec '{}', \
-                          ignoring it", s);
-                continue
-            }
-        };
-        dirs.push(Directive {
-            name: name.map(|s| s.to_string()),
-            level: log_level,
-        });
-    }});
+                    (Some(part0), Some(""), None) => (LevelFilter::max(), Some(part0)),
+                    (Some(part0), Some(part1), None) => match part1.parse() {
+                        Ok(num) => (num, Some(part0)),
+                        _ => {
+                            eprintln!(
+                                "warning: invalid logging spec '{}', \
+                                 ignoring it",
+                                part1
+                            );
+                            continue;
+                        }
+                    },
+                    _ => {
+                        eprintln!(
+                            "warning: invalid logging spec '{}', \
+                             ignoring it",
+                            s
+                        );
+                        continue;
+                    }
+                };
+            dirs.push(Directive {
+                name: name.map(|s| s.to_string()),
+                level: log_level,
+            });
+        }
+    });
 
-    let filter = filter.map_or(None, |filter| {
-        match inner::Filter::new(filter) {
-            Ok(re) => Some(re),
-            Err(e) => {
-                eprintln!("warning: invalid regex filter - {}", e);
-                None
-            }
+    let filter = filter.map_or(None, |filter| match inner::Filter::new(filter) {
+        Ok(re) => Some(re),
+        Err(e) => {
+            eprintln!("warning: invalid regex filter - {}", e);
+            None
         }
     });
 
     return (dirs, filter);
 }
 
-
 // Check whether a level and target are enabled by the set of directives.
 fn enabled(directives: &[Directive], level: Level, target: &str) -> bool {
     // Search for the longest match, the vector is assumed to be pre-sorted.
     for directive in directives.iter().rev() {
         match directive.name {
-            Some(ref name) if !target.starts_with(&**name) => {},
-            Some(..) | None => {
-                return level <= directive.level
-            }
+            Some(ref name) if !target.starts_with(&**name) => {}
+            Some(..) | None => return level <= directive.level,
         }
     }
     false
@@ -377,7 +381,7 @@ fn enabled(directives: &[Directive], level: Level, target: &str) -> bool {
 mod tests {
     use log::{Level, LevelFilter};
 
-    use super::{Builder, Filter, Directive, parse_spec, enabled};
+    use super::{enabled, parse_spec, Builder, Directive, Filter};
 
     fn make_logger_filter(dirs: Vec<Directive>) -> Filter {
         let mut logger = Builder::new().build();
@@ -395,10 +399,10 @@ mod tests {
     #[test]
     fn filter_beginning_longest_match() {
         let logger = Builder::new()
-                        .filter(Some("crate2"), LevelFilter::Info)
-                        .filter(Some("crate2::mod"), LevelFilter::Debug)
-                        .filter(Some("crate1::mod1"), LevelFilter::Warn)
-                        .build();
+            .filter(Some("crate2"), LevelFilter::Info)
+            .filter(Some("crate2::mod"), LevelFilter::Debug)
+            .filter(Some("crate1::mod1"), LevelFilter::Warn)
+            .build();
         assert!(enabled(&logger.directives, Level::Debug, "crate2::mod1"));
         assert!(!enabled(&logger.directives, Level::Debug, "crate2"));
     }
@@ -415,12 +419,12 @@ mod tests {
         let logger = make_logger_filter(vec![
             Directive {
                 name: Some("crate2".to_string()),
-                level: LevelFilter::Info
+                level: LevelFilter::Info,
             },
             Directive {
                 name: Some("crate1::mod1".to_string()),
-                level: LevelFilter::Warn
-            }
+                level: LevelFilter::Warn,
+            },
         ]);
         assert!(enabled(&logger.directives, Level::Warn, "crate1::mod1"));
         assert!(!enabled(&logger.directives, Level::Info, "crate1::mod1"));
@@ -431,8 +435,14 @@ mod tests {
     #[test]
     fn no_match() {
         let logger = make_logger_filter(vec![
-            Directive { name: Some("crate2".to_string()), level: LevelFilter::Info },
-            Directive { name: Some("crate1::mod1".to_string()), level: LevelFilter::Warn }
+            Directive {
+                name: Some("crate2".to_string()),
+                level: LevelFilter::Info,
+            },
+            Directive {
+                name: Some("crate1::mod1".to_string()),
+                level: LevelFilter::Warn,
+            },
         ]);
         assert!(!enabled(&logger.directives, Level::Warn, "crate3"));
     }
@@ -440,8 +450,14 @@ mod tests {
     #[test]
     fn match_beginning() {
         let logger = make_logger_filter(vec![
-            Directive { name: Some("crate2".to_string()), level: LevelFilter::Info },
-            Directive { name: Some("crate1::mod1".to_string()), level: LevelFilter::Warn }
+            Directive {
+                name: Some("crate2".to_string()),
+                level: LevelFilter::Info,
+            },
+            Directive {
+                name: Some("crate1::mod1".to_string()),
+                level: LevelFilter::Warn,
+            },
         ]);
         assert!(enabled(&logger.directives, Level::Info, "crate2::mod1"));
     }
@@ -449,9 +465,18 @@ mod tests {
     #[test]
     fn match_beginning_longest_match() {
         let logger = make_logger_filter(vec![
-            Directive { name: Some("crate2".to_string()), level: LevelFilter::Info },
-            Directive { name: Some("crate2::mod".to_string()), level: LevelFilter::Debug },
-            Directive { name: Some("crate1::mod1".to_string()), level: LevelFilter::Warn }
+            Directive {
+                name: Some("crate2".to_string()),
+                level: LevelFilter::Info,
+            },
+            Directive {
+                name: Some("crate2::mod".to_string()),
+                level: LevelFilter::Debug,
+            },
+            Directive {
+                name: Some("crate1::mod1".to_string()),
+                level: LevelFilter::Warn,
+            },
         ]);
         assert!(enabled(&logger.directives, Level::Debug, "crate2::mod1"));
         assert!(!enabled(&logger.directives, Level::Debug, "crate2"));
@@ -460,8 +485,14 @@ mod tests {
     #[test]
     fn match_default() {
         let logger = make_logger_filter(vec![
-            Directive { name: None, level: LevelFilter::Info },
-            Directive { name: Some("crate1::mod1".to_string()), level: LevelFilter::Warn }
+            Directive {
+                name: None,
+                level: LevelFilter::Info,
+            },
+            Directive {
+                name: Some("crate1::mod1".to_string()),
+                level: LevelFilter::Warn,
+            },
         ]);
         assert!(enabled(&logger.directives, Level::Warn, "crate1::mod1"));
         assert!(enabled(&logger.directives, Level::Info, "crate2::mod2"));
@@ -470,8 +501,14 @@ mod tests {
     #[test]
     fn zero_level() {
         let logger = make_logger_filter(vec![
-            Directive { name: None, level: LevelFilter::Info },
-            Directive { name: Some("crate1::mod1".to_string()), level: LevelFilter::Off }
+            Directive {
+                name: None,
+                level: LevelFilter::Info,
+            },
+            Directive {
+                name: Some("crate1::mod1".to_string()),
+                level: LevelFilter::Off,
+            },
         ]);
         assert!(!enabled(&logger.directives, Level::Error, "crate1::mod1"));
         assert!(enabled(&logger.directives, Level::Info, "crate2::mod2"));

--- a/src/filter/regex.rs
+++ b/src/filter/regex.rs
@@ -11,7 +11,7 @@ pub struct Filter {
 
 impl Filter {
     pub fn new(spec: &str) -> Result<Filter, String> {
-        match Regex::new(spec){
+        match Regex::new(spec) {
             Ok(r) => Ok(Filter { inner: r }),
             Err(e) => Err(e.to_string()),
         }

--- a/src/filter/string.rs
+++ b/src/filter/string.rs
@@ -7,7 +7,9 @@ pub struct Filter {
 
 impl Filter {
     pub fn new(spec: &str) -> Result<Filter, String> {
-        Ok(Filter { inner: spec.to_string() })
+        Ok(Filter {
+            inner: spec.to_string(),
+        })
     }
 
     pub fn is_match(&self, s: &str) -> bool {

--- a/src/fmt/humantime/extern_impl.rs
+++ b/src/fmt/humantime/extern_impl.rs
@@ -2,13 +2,12 @@ use std::fmt;
 use std::time::SystemTime;
 
 use humantime::{
-    format_rfc3339_micros, format_rfc3339_millis,
-    format_rfc3339_nanos, format_rfc3339_seconds,
+    format_rfc3339_micros, format_rfc3339_millis, format_rfc3339_nanos, format_rfc3339_seconds,
 };
 
-use ::fmt::{Formatter, TimestampPrecision};
+use crate::fmt::{Formatter, TimestampPrecision};
 
-pub(in ::fmt) mod glob {
+pub(in crate::fmt) mod glob {
     pub use super::*;
 }
 
@@ -74,12 +73,6 @@ impl Formatter {
             precision: TimestampPrecision::Nanos,
         }
     }
-
-    /// Get a [`PreciseTimestamp`] for the current date and time in UTC with nanos.
-    #[deprecated = "Use timestamp_nanos() instead"]
-    pub fn precise_timestamp(&self) -> PreciseTimestamp {
-        PreciseTimestamp(SystemTime::now())
-    }
 }
 
 /// An [RFC3339] formatted timestamp.
@@ -94,12 +87,6 @@ pub struct Timestamp {
     precision: TimestampPrecision,
 }
 
-/// An [RFC3339] formatted timestamp with nanos.
-///
-/// [RFC3339]: https://www.ietf.org/rfc/rfc3339.txt
-#[derive(Debug)]
-pub struct PreciseTimestamp(SystemTime);
-
 impl fmt::Debug for Timestamp {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         /// A `Debug` wrapper for `Timestamp` that uses the `Display` implementation.
@@ -112,8 +99,8 @@ impl fmt::Debug for Timestamp {
         }
 
         f.debug_tuple("Timestamp")
-        .field(&TimestampValue(&self))
-        .finish()
+            .field(&TimestampValue(&self))
+            .finish()
     }
 }
 
@@ -127,11 +114,5 @@ impl fmt::Display for Timestamp {
         };
 
         formatter(self.time).fmt(f)
-    }
-}
-
-impl fmt::Display for PreciseTimestamp {
-    fn fmt(&self, f: &mut fmt::Formatter)->fmt::Result {
-        format_rfc3339_nanos(self.0).fmt(f)
     }
 }

--- a/src/fmt/humantime/mod.rs
+++ b/src/fmt/humantime/mod.rs
@@ -8,4 +8,4 @@ Its public API is available when the `humantime` crate is available.
 #[cfg_attr(not(feature = "humantime"), path = "shim_impl.rs")]
 mod imp;
 
-pub(in ::fmt) use self::imp::*;
+pub(in crate::fmt) use self::imp::*;

--- a/src/fmt/humantime/shim_impl.rs
+++ b/src/fmt/humantime/shim_impl.rs
@@ -2,6 +2,4 @@
 Timestamps aren't available when we don't have a `humantime` dependency.
 */
 
-pub(in ::fmt) mod glob {
-    
-}
+pub(in crate::fmt) mod glob {}

--- a/src/fmt/writer/atty.rs
+++ b/src/fmt/writer/atty.rs
@@ -11,24 +11,24 @@ from being printed.
 mod imp {
     use atty;
 
-    pub(in ::fmt) fn is_stdout() -> bool {
+    pub(in crate::fmt) fn is_stdout() -> bool {
         atty::is(atty::Stream::Stdout)
     }
 
-    pub(in ::fmt) fn is_stderr() -> bool {
+    pub(in crate::fmt) fn is_stderr() -> bool {
         atty::is(atty::Stream::Stderr)
     }
 }
 
 #[cfg(not(feature = "atty"))]
 mod imp {
-    pub(in ::fmt) fn is_stdout() -> bool {
+    pub(in crate::fmt) fn is_stdout() -> bool {
         false
     }
 
-    pub(in ::fmt) fn is_stderr() -> bool {
+    pub(in crate::fmt) fn is_stderr() -> bool {
         false
     }
 }
 
-pub(in ::fmt) use self::imp::*;
+pub(in crate::fmt) use self::imp::*;

--- a/src/fmt/writer/mod.rs
+++ b/src/fmt/writer/mod.rs
@@ -1,16 +1,16 @@
-mod termcolor;
 mod atty;
+mod termcolor;
 
-use std::{fmt, io};
+use self::atty::{is_stderr, is_stdout};
 use self::termcolor::BufferWriter;
-use self::atty::{is_stdout, is_stderr};
+use std::{fmt, io};
 
-pub(in ::fmt) mod glob {
+pub(in crate::fmt) mod glob {
     pub use super::termcolor::glob::*;
     pub use super::*;
 }
 
-pub(in ::fmt) use self::termcolor::Buffer;
+pub(in crate::fmt) use self::termcolor::Buffer;
 
 /// Log target, either `stdout` or `stderr`.
 #[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
@@ -55,11 +55,11 @@ impl Writer {
         self.write_style
     }
 
-    pub(in ::fmt) fn buffer(&self) -> Buffer {
+    pub(in crate::fmt) fn buffer(&self) -> Buffer {
         self.inner.buffer()
     }
 
-    pub(in ::fmt) fn print(&self, buf: &Buffer) -> io::Result<()> {
+    pub(in crate::fmt) fn print(&self, buf: &Buffer) -> io::Result<()> {
         self.inner.print(buf)
     }
 }
@@ -127,7 +127,7 @@ impl Builder {
                 } else {
                     WriteStyle::Never
                 }
-            },
+            }
             color_choice => color_choice,
         };
 
@@ -150,16 +150,16 @@ impl Default for Builder {
 }
 
 impl fmt::Debug for Builder {
-    fn fmt(&self, f: &mut fmt::Formatter)->fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         f.debug_struct("Logger")
-        .field("target", &self.target)
-        .field("write_style", &self.write_style)
-        .finish()
+            .field("target", &self.target)
+            .field("write_style", &self.write_style)
+            .finish()
     }
 }
 
 impl fmt::Debug for Writer {
-    fn fmt(&self, f: &mut fmt::Formatter)->fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         f.debug_struct("Writer").finish()
     }
 }
@@ -192,12 +192,7 @@ mod tests {
 
     #[test]
     fn parse_write_style_invalid() {
-        let inputs = vec![
-            "",
-            "true",
-            "false",
-            "NEVER!!"
-        ];
+        let inputs = vec!["", "true", "false", "NEVER!!"];
 
         for input in inputs {
             assert_eq!(WriteStyle::Auto, parse_write_style(input));

--- a/src/fmt/writer/termcolor/mod.rs
+++ b/src/fmt/writer/termcolor/mod.rs
@@ -9,4 +9,4 @@ The terminal printing is shimmed when the `termcolor` crate is not available.
 #[cfg_attr(not(feature = "termcolor"), path = "shim_impl.rs")]
 mod imp;
 
-pub(in ::fmt) use self::imp::*;
+pub(in crate::fmt) use self::imp::*;

--- a/src/fmt/writer/termcolor/shim_impl.rs
+++ b/src/fmt/writer/termcolor/shim_impl.rs
@@ -1,35 +1,33 @@
 use std::io;
 
-use fmt::{WriteStyle, Target};
+use crate::fmt::{Target, WriteStyle};
 
-pub(in ::fmt::writer) mod glob {
-    
-}
+pub(in crate::fmt::writer) mod glob {}
 
-pub(in ::fmt::writer) struct BufferWriter {
+pub(in crate::fmt::writer) struct BufferWriter {
     target: Target,
 }
 
-pub(in ::fmt) struct Buffer(Vec<u8>);
+pub(in crate::fmt) struct Buffer(Vec<u8>);
 
 impl BufferWriter {
-    pub(in ::fmt::writer) fn stderr(_is_test: bool, _write_style: WriteStyle) -> Self {
+    pub(in crate::fmt::writer) fn stderr(_is_test: bool, _write_style: WriteStyle) -> Self {
         BufferWriter {
             target: Target::Stderr,
         }
     }
 
-    pub(in ::fmt::writer) fn stdout(_is_test: bool, _write_style: WriteStyle) -> Self {
+    pub(in crate::fmt::writer) fn stdout(_is_test: bool, _write_style: WriteStyle) -> Self {
         BufferWriter {
             target: Target::Stdout,
         }
     }
 
-    pub(in ::fmt::writer) fn buffer(&self) -> Buffer {
+    pub(in crate::fmt::writer) fn buffer(&self) -> Buffer {
         Buffer(Vec::new())
     }
 
-    pub(in ::fmt::writer) fn print(&self, buf: &Buffer) -> io::Result<()> {
+    pub(in crate::fmt::writer) fn print(&self, buf: &Buffer) -> io::Result<()> {
         // This impl uses the `eprint` and `print` macros
         // instead of using the streams directly.
         // This is so their output can be captured by `cargo test`
@@ -45,21 +43,21 @@ impl BufferWriter {
 }
 
 impl Buffer {
-    pub(in ::fmt) fn clear(&mut self) {
+    pub(in crate::fmt) fn clear(&mut self) {
         self.0.clear();
     }
 
-    pub(in ::fmt) fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
+    pub(in crate::fmt) fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
         self.0.extend(buf);
         Ok(buf.len())
     }
 
-    pub(in ::fmt) fn flush(&mut self) -> io::Result<()> {
+    pub(in crate::fmt) fn flush(&mut self) -> io::Result<()> {
         Ok(())
     }
 
     #[cfg(test)]
-    pub(in ::fmt) fn bytes(&self) -> &[u8] {
+    pub(in crate::fmt) fn bytes(&self) -> &[u8] {
         &self.0
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -16,7 +16,6 @@
 //!
 //! ```
 //! #[macro_use] extern crate log;
-//! extern crate env_logger;
 //!
 //! use log::Level;
 //!
@@ -139,33 +138,32 @@
 //! * `error,hello=warn/[0-9]scopes` turn on global error logging and also
 //!   warn for hello. In both cases the log message must include a single digit
 //!   number followed by 'scopes'.
-//! 
+//!
 //! ## Capturing logs in tests
-//! 
+//!
 //! Records logged during `cargo test` will not be captured by the test harness by default.
 //! The [`Builder::is_test`] method can be used in unit tests to ensure logs will be captured:
-//! 
+//!
 //! ```
 //! # #[macro_use] extern crate log;
-//! # extern crate env_logger;
 //! # fn main() {}
 //! #[cfg(test)]
 //! mod tests {
 //!     fn init() {
 //!         let _ = env_logger::builder().is_test(true).try_init();
 //!     }
-//! 
+//!
 //!     #[test]
 //!     fn it_works() {
 //!         init();
-//! 
+//!
 //!         info!("This record will be captured by `cargo test`");
-//! 
+//!
 //!         assert_eq!(2, 1 + 1);
 //!     }
 //! }
 //! ```
-//! 
+//!
 //! Enabling test capturing comes at the expense of color and other style support
 //! and may have performance implications.
 //!
@@ -179,32 +177,32 @@
 //! * `always` will always print style characters even if they aren't supported by the terminal.
 //! This includes emitting ANSI colors on Windows if the console API is unavailable.
 //! * `never` will never print style characters.
-//! 
+//!
 //! ## Tweaking the default format
-//! 
+//!
 //! Parts of the default format can be excluded from the log output using the [`Builder`].
 //! The following example excludes the timestamp from the log output:
-//! 
+//!
 //! ```
 //! env_logger::builder()
-//!     .default_format_timestamp(false)
+//!     .format_timestamp(None)
 //!     .init();
 //! ```
-//! 
+//!
 //! ### Stability of the default format
-//! 
-//! The default format won't optimise for long-term stability, and explicitly makes no 
-//! guarantees about the stability of its output across major, minor or patch version 
+//!
+//! The default format won't optimise for long-term stability, and explicitly makes no
+//! guarantees about the stability of its output across major, minor or patch version
 //! bumps during `0.x`.
-//! 
-//! If you want to capture or interpret the output of `env_logger` programmatically 
+//!
+//! If you want to capture or interpret the output of `env_logger` programmatically
 //! then you should use a custom format.
-//! 
+//!
 //! ### Using a custom format
-//! 
+//!
 //! Custom formats can be provided as closures to the [`Builder`].
 //! These closures take a [`Formatter`] and `log::Record` as arguments:
-//! 
+//!
 //! ```
 //! use std::io::Write;
 //!
@@ -214,54 +212,43 @@
 //!     })
 //!     .init();
 //! ```
-//! 
+//!
 //! See the [`fmt`] module for more details about custom formats.
-//! 
+//!
 //! ## Specifying defaults for environment variables
-//! 
+//!
 //! `env_logger` can read configuration from environment variables.
 //! If these variables aren't present, the default value to use can be tweaked with the [`Env`] type.
 //! The following example defaults to log `warn` and above if the `RUST_LOG` environment variable
 //! isn't set:
-//! 
+//!
 //! ```
 //! use env_logger::Env;
 //!
 //! env_logger::from_env(Env::default().default_filter_or("warn")).init();
 //! ```
-//! 
+//!
 //! [log-crate-url]: https://docs.rs/log/
 //! [`Builder`]: struct.Builder.html
 //! [`Builder::is_test`]: struct.Builder.html#method.is_test
 //! [`Env`]: struct.Env.html
 //! [`fmt`]: fmt/index.html
 
-#![doc(html_logo_url = "https://www.rust-lang.org/logos/rust-logo-128x128-blk-v2.png",
-       html_favicon_url = "https://www.rust-lang.org/static/images/favicon.ico",
-       html_root_url = "https://docs.rs/env_logger/0.6.2")]
+#![doc(
+    html_logo_url = "https://www.rust-lang.org/logos/rust-logo-128x128-blk-v2.png",
+    html_favicon_url = "https://www.rust-lang.org/static/images/favicon.ico",
+    html_root_url = "https://docs.rs/env_logger/0.6.2"
+)]
 #![cfg_attr(test, deny(warnings))]
-
 // When compiled for the rustc compiler itself we want to make sure that this is
 // an unstable crate
 #![cfg_attr(rustbuild, feature(staged_api, rustc_private))]
 #![cfg_attr(rustbuild, unstable(feature = "rustc_private", issue = "27812"))]
-
 #![deny(missing_debug_implementations, missing_docs, warnings)]
 
-extern crate log;
+use std::{borrow::Cow, cell::RefCell, env, io};
 
-#[cfg(feature = "termcolor")]
-extern crate termcolor;
-#[cfg(feature = "humantime")]
-extern crate humantime;
-#[cfg(feature = "atty")]
-extern crate atty;
-
-use std::{env, io};
-use std::borrow::Cow;
-use std::cell::RefCell;
-
-use log::{Log, LevelFilter, Record, SetLoggerError, Metadata};
+use log::{LevelFilter, Log, Metadata, Record, SetLoggerError};
 
 pub mod filter;
 pub mod fmt;
@@ -269,8 +256,8 @@ pub mod fmt;
 pub use self::fmt::glob::*;
 
 use self::filter::Filter;
-use self::fmt::{Formatter, TimestampPrecision};
 use self::fmt::writer::{self, Writer};
+use self::fmt::Formatter;
 
 /// The default name for the environment variable to read filters from.
 pub const DEFAULT_FILTER_ENV: &'static str = "RUST_LOG";
@@ -334,9 +321,7 @@ pub struct Logger {
 /// # Examples
 ///
 /// ```
-/// #[macro_use]
-/// extern crate log;
-/// extern crate env_logger;
+/// #[macro_use] extern crate log;
 ///
 /// use std::env;
 /// use std::io::Write;
@@ -364,30 +349,28 @@ pub struct Builder {
 
 impl Builder {
     /// Initializes the log builder with defaults.
-    /// 
+    ///
     /// **NOTE:** This method won't read from any environment variables.
     /// Use the [`filter`] and [`write_style`] methods to configure the builder
     /// or use [`from_env`] or [`from_default_env`] instead.
-    /// 
+    ///
     /// # Examples
-    /// 
+    ///
     /// Create a new builder and configure filters and style:
-    /// 
+    ///
     /// ```
-    /// # extern crate log;
-    /// # extern crate env_logger;
     /// # fn main() {
     /// use log::LevelFilter;
     /// use env_logger::{Builder, WriteStyle};
-    /// 
+    ///
     /// let mut builder = Builder::new();
-    /// 
+    ///
     /// builder.filter(None, LevelFilter::Info)
     ///        .write_style(WriteStyle::Always)
     ///        .init();
     /// # }
     /// ```
-    /// 
+    ///
     /// [`filter`]: #method.filter
     /// [`write_style`]: #method.write_style
     /// [`from_env`]: #method.from_env
@@ -402,13 +385,13 @@ impl Builder {
     /// passing in.
     ///
     /// # Examples
-    /// 
+    ///
     /// Initialise a logger reading the log filter from an environment variable
     /// called `MY_LOG`:
-    /// 
+    ///
     /// ```
     /// use env_logger::Builder;
-    /// 
+    ///
     /// let mut builder = Builder::from_env("MY_LOG");
     /// builder.init();
     /// ```
@@ -426,7 +409,7 @@ impl Builder {
     /// ```
     pub fn from_env<'a, E>(env: E) -> Self
     where
-        E: Into<Env<'a>>
+        E: Into<Env<'a>>,
     {
         let mut builder = Builder::new();
         let env = env.into();
@@ -443,18 +426,18 @@ impl Builder {
     }
 
     /// Initializes the log builder from the environment using default variable names.
-    /// 
+    ///
     /// This method is a convenient way to call `from_env(Env::default())` without
     /// having to use the `Env` type explicitly. The builder will use the
     /// [default environment variables].
-    /// 
+    ///
     /// # Examples
-    /// 
+    ///
     /// Initialise a logger using the default environment variables:
-    /// 
+    ///
     /// ```
     /// use env_logger::Builder;
-    /// 
+    ///
     /// let mut builder = Builder::from_default_env();
     /// builder.init();
     /// ```
@@ -473,17 +456,17 @@ impl Builder {
     /// `Formatter` so that implementations can use the [`std::fmt`] macros
     /// to format and output without intermediate heap allocations. The default
     /// `env_logger` formatter takes advantage of this.
-    /// 
+    ///
     /// # Examples
-    /// 
+    ///
     /// Use a custom format to write only the log message:
-    /// 
+    ///
     /// ```
     /// use std::io::Write;
     /// use env_logger::Builder;
-    /// 
+    ///
     /// let mut builder = Builder::new();
-    /// 
+    ///
     /// builder.format(|buf, record| writeln!(buf, "{}", record.args()));
     /// ```
     ///
@@ -491,63 +474,64 @@ impl Builder {
     /// [`String`]: https://doc.rust-lang.org/stable/std/string/struct.String.html
     /// [`std::fmt`]: https://doc.rust-lang.org/std/fmt/index.html
     pub fn format<F: 'static>(&mut self, format: F) -> &mut Self
-        where F: Fn(&mut Formatter, &Record) -> io::Result<()> + Sync + Send
+    where
+        F: Fn(&mut Formatter, &Record) -> io::Result<()> + Sync + Send,
     {
         self.format.custom_format = Some(Box::new(format));
         self
     }
 
     /// Use the default format.
-    /// 
+    ///
     /// This method will clear any custom format set on the builder.
     pub fn default_format(&mut self) -> &mut Self {
-        self.format.custom_format = None;
+        self.format = Default::default();
         self
     }
 
     /// Whether or not to write the level in the default format.
-    pub fn default_format_level(&mut self, write: bool) -> &mut Self {
-        self.format.default_format_level = write;
+    pub fn format_level(&mut self, write: bool) -> &mut Self {
+        self.format.format_level = write;
         self
     }
 
     /// Whether or not to write the module path in the default format.
-    pub fn default_format_module_path(&mut self, write: bool) -> &mut Self {
-        self.format.default_format_module_path = write;
+    pub fn format_module_path(&mut self, write: bool) -> &mut Self {
+        self.format.format_module_path = write;
         self
     }
 
     /// Configures the amount of spaces to use to indent multiline log records.
     /// A value of `None` disables any kind of indentation.
-    pub fn default_format_indent(&mut self, indent: Option<usize>) -> &mut Self {
-        self.format.default_format_indent = indent;
+    pub fn format_indent(&mut self, indent: Option<usize>) -> &mut Self {
+        self.format.format_indent = indent;
         self
     }
 
     /// Configures if timestamp should be included and in what precision.
-    pub fn default_format_timestamp(&mut self, timestamp: Option<TimestampPrecision>) -> &mut Self {
-        self.format.default_format_timestamp = timestamp;
+    pub fn format_timestamp(&mut self, timestamp: Option<fmt::TimestampPrecision>) -> &mut Self {
+        self.format.format_timestamp = timestamp;
         self
     }
 
     /// Configures the timestamp to use second precision.
-    pub fn default_format_timestamp_secs(&mut self) -> &mut Self {
-        self.default_format_timestamp(Some(TimestampPrecision::Seconds))
+    pub fn format_timestamp_secs(&mut self) -> &mut Self {
+        self.format_timestamp(Some(fmt::TimestampPrecision::Seconds))
     }
 
     /// Configures the timestamp to use millisecond precision.
-    pub fn default_format_timestamp_millis(&mut self) -> &mut Self {
-        self.default_format_timestamp(Some(TimestampPrecision::Millis))
+    pub fn format_timestamp_millis(&mut self) -> &mut Self {
+        self.format_timestamp(Some(fmt::TimestampPrecision::Millis))
     }
 
     /// Configures the timestamp to use microsecond precision.
-    pub fn default_format_timestamp_micros(&mut self) -> &mut Self {
-        self.default_format_timestamp(Some(TimestampPrecision::Micros))
+    pub fn format_timestamp_micros(&mut self) -> &mut Self {
+        self.format_timestamp(Some(fmt::TimestampPrecision::Micros))
     }
 
     /// Configures the timestamp to use nanosecond precision.
-    pub fn default_format_timestamp_nanos(&mut self) -> &mut Self {
-        self.default_format_timestamp(Some(TimestampPrecision::Nanos))
+    pub fn format_timestamp_nanos(&mut self) -> &mut Self {
+        self.format_timestamp(Some(fmt::TimestampPrecision::Nanos))
     }
 
     /// Adds a directive to the filter for a specific module.
@@ -557,8 +541,6 @@ impl Builder {
     /// Only include messages for warning and above for logs in `path::to::module`:
     ///
     /// ```
-    /// # extern crate log;
-    /// # extern crate env_logger;
     /// # fn main() {
     /// use log::LevelFilter;
     /// use env_logger::Builder;
@@ -580,8 +562,6 @@ impl Builder {
     /// Only include messages for warning and above for logs in `path::to::module`:
     ///
     /// ```
-    /// # extern crate log;
-    /// # extern crate env_logger;
     /// # fn main() {
     /// use log::LevelFilter;
     /// use env_logger::Builder;
@@ -600,37 +580,24 @@ impl Builder {
     ///
     /// The given module (if any) will log at most the specified level provided.
     /// If no module is provided then the filter will apply to all log messages.
-    /// 
+    ///
     /// # Examples
-    /// 
+    ///
     /// Only include messages for warning and above for logs in `path::to::module`:
-    /// 
+    ///
     /// ```
-    /// # extern crate log;
-    /// # extern crate env_logger;
     /// # fn main() {
     /// use log::LevelFilter;
     /// use env_logger::Builder;
-    /// 
+    ///
     /// let mut builder = Builder::new();
-    /// 
+    ///
     /// builder.filter(Some("path::to::module"), LevelFilter::Info);
     /// # }
     /// ```
-    pub fn filter(&mut self,
-                  module: Option<&str>,
-                  level: LevelFilter) -> &mut Self {
+    pub fn filter(&mut self, module: Option<&str>, level: LevelFilter) -> &mut Self {
         self.filter.filter(module, level);
         self
-    }
-
-    /// Parses the directives string in the same form as the `RUST_LOG`
-    /// environment variable.
-    ///
-    /// See the module documentation for more details.
-    #[deprecated(since = "0.6.1", note = "use `parse_filters` instead.")]
-    pub fn parse(&mut self, filters: &str) -> &mut Self {
-        self.parse_filters(filters)
     }
 
     /// Parses the directives string in the same form as the `RUST_LOG`
@@ -645,16 +612,16 @@ impl Builder {
     /// Sets the target for the log output.
     ///
     /// Env logger can log to either stdout or stderr. The default is stderr.
-    /// 
+    ///
     /// # Examples
-    /// 
+    ///
     /// Write log message to `stdout`:
-    /// 
+    ///
     /// ```
     /// use env_logger::{Builder, Target};
-    /// 
+    ///
     /// let mut builder = Builder::new();
-    /// 
+    ///
     /// builder.target(Target::Stdout);
     /// ```
     pub fn target(&mut self, target: fmt::Target) -> &mut Self {
@@ -666,16 +633,16 @@ impl Builder {
     ///
     /// This can be useful in environments that don't support control characters
     /// for setting colors.
-    /// 
+    ///
     /// # Examples
-    /// 
+    ///
     /// Never attempt to write styles:
-    /// 
+    ///
     /// ```
     /// use env_logger::{Builder, WriteStyle};
-    /// 
+    ///
     /// let mut builder = Builder::new();
-    /// 
+    ///
     /// builder.write_style(WriteStyle::Never);
     /// ```
     pub fn write_style(&mut self, write_style: fmt::WriteStyle) -> &mut Self {
@@ -693,7 +660,7 @@ impl Builder {
     }
 
     /// Sets whether or not the logger will be used in unit tests.
-    /// 
+    ///
     /// If `is_test` is `true` then the logger will allow the testing framework to
     /// capture log records rather than printing them to the terminal directly.
     pub fn is_test(&mut self, is_test: bool) -> &mut Self {
@@ -733,7 +700,8 @@ impl Builder {
     /// This function will panic if it is called more than once, or if another
     /// library has already initialized a global logger.
     pub fn init(&mut self) {
-        self.try_init().expect("Builder::init should not be called after logger initialized");
+        self.try_init()
+            .expect("Builder::init should not be called after logger initialized");
     }
 
     /// Build an env logger.
@@ -780,8 +748,8 @@ impl Logger {
     /// let logger = Logger::from_env(env);
     /// ```
     pub fn from_env<'a, E>(env: E) -> Self
-        where
-            E: Into<Env<'a>>
+    where
+        E: Into<Env<'a>>,
     {
         Builder::from_env(env).build()
     }
@@ -861,14 +829,15 @@ impl Log for Logger {
                         if formatter.write_style() != self.writer.write_style() {
                             *formatter = Formatter::new(&self.writer)
                         }
-                    },
-                    ref mut tl_buf => *tl_buf = Some(Formatter::new(&self.writer))
+                    }
+                    ref mut tl_buf => *tl_buf = Some(Formatter::new(&self.writer)),
                 }
 
                 // The format is guaranteed to be `Some` by this point
                 let mut formatter = tl_buf.as_mut().unwrap();
 
-                let _ = (self.format)(&mut formatter, record).and_then(|_| formatter.print(&self.writer));
+                let _ = (self.format)(&mut formatter, record)
+                    .and_then(|_| formatter.print(&self.writer));
 
                 // Always clear the buffer afterwards
                 formatter.clear();
@@ -888,7 +857,7 @@ impl<'a> Env<'a> {
     /// Specify an environment variable to read the filter from.
     pub fn filter<E>(mut self, filter_env: E) -> Self
     where
-        E: Into<Cow<'a, str>>
+        E: Into<Cow<'a, str>>,
     {
         self.filter = Var::new(filter_env);
 
@@ -909,7 +878,7 @@ impl<'a> Env<'a> {
     }
 
     /// Use the default environment variable to read the filter from.
-    /// 
+    ///
     /// If the variable is not set, the default value will be used.
     pub fn default_filter_or<V>(mut self, default: V) -> Self
     where
@@ -927,7 +896,7 @@ impl<'a> Env<'a> {
     /// Specify an environment variable to read the style from.
     pub fn write_style<E>(mut self, write_style_env: E) -> Self
     where
-        E: Into<Cow<'a, str>>
+        E: Into<Cow<'a, str>>,
     {
         self.write_style = Var::new(write_style_env);
 
@@ -938,9 +907,9 @@ impl<'a> Env<'a> {
     ///
     /// If the variable is not set, the default value will be used.
     pub fn write_style_or<E, V>(mut self, write_style_env: E, default: V) -> Self
-        where
-            E: Into<Cow<'a, str>>,
-            V: Into<Cow<'a, str>>,
+    where
+        E: Into<Cow<'a, str>>,
+        V: Into<Cow<'a, str>>,
     {
         self.write_style = Var::new_with_default(write_style_env, default);
 
@@ -951,8 +920,8 @@ impl<'a> Env<'a> {
     ///
     /// If the variable is not set, the default value will be used.
     pub fn default_write_style_or<V>(mut self, default: V) -> Self
-        where
-            V: Into<Cow<'a, str>>,
+    where
+        V: Into<Cow<'a, str>>,
     {
         self.write_style = Var::new_with_default(DEFAULT_WRITE_STYLE_ENV, default);
 
@@ -966,8 +935,8 @@ impl<'a> Env<'a> {
 
 impl<'a> Var<'a> {
     fn new<E>(name: E) -> Self
-        where
-            E: Into<Cow<'a, str>>,
+    where
+        E: Into<Cow<'a, str>>,
     {
         Var {
             name: name.into(),
@@ -989,15 +958,13 @@ impl<'a> Var<'a> {
     fn get(&self) -> Option<String> {
         env::var(&*self.name)
             .ok()
-            .or_else(|| self.default
-                .to_owned()
-                .map(|v| v.into_owned()))
+            .or_else(|| self.default.to_owned().map(|v| v.into_owned()))
     }
 }
 
 impl<'a, T> From<T> for Env<'a>
 where
-    T: Into<Cow<'a, str>>
+    T: Into<Cow<'a, str>>,
 {
     fn from(filter_env: T) -> Self {
         Env::default().filter(filter_env.into())
@@ -1014,28 +981,26 @@ impl<'a> Default for Env<'a> {
 }
 
 mod std_fmt_impls {
-    use std::fmt;
     use super::*;
+    use std::fmt;
 
-    impl fmt::Debug for Logger{
-        fn fmt(&self, f: &mut fmt::Formatter)->fmt::Result {
+    impl fmt::Debug for Logger {
+        fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
             f.debug_struct("Logger")
                 .field("filter", &self.filter)
                 .finish()
         }
     }
 
-    impl fmt::Debug for Builder{
-        fn fmt(&self, f: &mut fmt::Formatter)->fmt::Result {
+    impl fmt::Debug for Builder {
+        fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
             if self.built {
-                f.debug_struct("Logger")
-                .field("built", &true)
-                .finish()
+                f.debug_struct("Logger").field("built", &true).finish()
             } else {
                 f.debug_struct("Logger")
-                .field("filter", &self.filter)
-                .field("writer", &self.writer)
-                .finish()
+                    .field("filter", &self.filter)
+                    .field("writer", &self.writer)
+                    .finish()
             }
         }
     }
@@ -1098,7 +1063,7 @@ pub fn init() {
 /// library has already initialized a global logger.
 pub fn try_init_from_env<'a, E>(env: E) -> Result<(), SetLoggerError>
 where
-    E: Into<Env<'a>>
+    E: Into<Env<'a>>,
 {
     let mut builder = Builder::from_env(env);
 
@@ -1130,24 +1095,25 @@ where
 /// library has already initialized a global logger.
 pub fn init_from_env<'a, E>(env: E)
 where
-    E: Into<Env<'a>>
+    E: Into<Env<'a>>,
 {
-    try_init_from_env(env).expect("env_logger::init_from_env should not be called after logger initialized");
+    try_init_from_env(env)
+        .expect("env_logger::init_from_env should not be called after logger initialized");
 }
 
 /// Create a new builder with the default environment variables.
-/// 
+///
 /// The builder can be configured before being initialized.
 pub fn builder() -> Builder {
     Builder::from_default_env()
 }
 
 /// Create a builder from the given environment variables.
-/// 
+///
 /// The builder can be configured before being initialized.
 pub fn from_env<'a, E>(env: E) -> Builder
 where
-    E: Into<Env<'a>>
+    E: Into<Env<'a>>,
 {
     Builder::from_env(env)
 }
@@ -1169,7 +1135,10 @@ mod tests {
     fn env_get_filter_reads_from_default_if_var_not_set() {
         env::remove_var("env_get_filter_reads_from_default_if_var_not_set");
 
-        let env = Env::new().filter_or("env_get_filter_reads_from_default_if_var_not_set", "from default");
+        let env = Env::new().filter_or(
+            "env_get_filter_reads_from_default_if_var_not_set",
+            "from default",
+        );
 
         assert_eq!(Some("from default".to_owned()), env.get_filter());
     }
@@ -1178,7 +1147,8 @@ mod tests {
     fn env_get_write_style_reads_from_var_if_set() {
         env::set_var("env_get_write_style_reads_from_var_if_set", "from var");
 
-        let env = Env::new().write_style_or("env_get_write_style_reads_from_var_if_set", "from default");
+        let env =
+            Env::new().write_style_or("env_get_write_style_reads_from_var_if_set", "from default");
 
         assert_eq!(Some("from var".to_owned()), env.get_write_style());
     }
@@ -1187,7 +1157,10 @@ mod tests {
     fn env_get_write_style_reads_from_default_if_var_not_set() {
         env::remove_var("env_get_write_style_reads_from_default_if_var_not_set");
 
-        let env = Env::new().write_style_or("env_get_write_style_reads_from_default_if_var_not_set", "from default");
+        let env = Env::new().write_style_or(
+            "env_get_write_style_reads_from_default_if_var_not_set",
+            "from default",
+        );
 
         assert_eq!(Some("from default".to_owned()), env.get_write_style());
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -269,10 +269,8 @@ pub mod fmt;
 pub use self::fmt::glob::*;
 
 use self::filter::Filter;
-use self::fmt::Formatter;
+use self::fmt::{Formatter, TimestampPrecision};
 use self::fmt::writer::{self, Writer};
-
-pub use self::fmt::TimestampPrecision as Timestamp;
 
 /// The default name for the environment variable to read filters from.
 pub const DEFAULT_FILTER_ENV: &'static str = "RUST_LOG";
@@ -519,28 +517,6 @@ impl Builder {
         self
     }
 
-    /// Whether or not to write the timestamp in the default format.
-    #[deprecated = "Use format_timestamp() instead"]
-    pub fn default_format_timestamp(&mut self, write: bool) -> &mut Self {
-        if write {
-            self.format_timestamp(Some(Timestamp::Seconds));
-        } else {
-            self.format_timestamp(None);
-        }
-        self
-    }
-
-    /// Whether or not to write the timestamp with nanosecond precision.
-    #[deprecated = "Use format_timestamp() instead"]
-    pub fn default_format_timestamp_nanos(&mut self, write: bool) -> &mut Self {
-        // The old logic included two booleans: One for timestamp on/off and one
-        // for nanosecond precision. Mimic it here for compatibility.
-        if write && self.format.default_format_timestamp.is_some() {
-            self.format.default_format_timestamp = Some(fmt::TimestampPrecision::Nanos);
-        }
-        self
-    }
-
     /// Configures the amount of spaces to use to indent multiline log records.
     /// A value of `None` disables any kind of indentation.
     pub fn default_format_indent(&mut self, indent: Option<usize>) -> &mut Self {
@@ -549,9 +525,29 @@ impl Builder {
     }
 
     /// Configures if timestamp should be included and in what precision.
-    pub fn format_timestamp(&mut self, timestamp: Option<Timestamp>) -> &mut Self {
+    pub fn default_format_timestamp(&mut self, timestamp: Option<TimestampPrecision>) -> &mut Self {
         self.format.default_format_timestamp = timestamp;
         self
+    }
+
+    /// Configures the timestamp to use second precision.
+    pub fn default_format_timestamp_secs(&mut self) -> &mut Self {
+        self.default_format_timestamp(Some(TimestampPrecision::Seconds))
+    }
+
+    /// Configures the timestamp to use millisecond precision.
+    pub fn default_format_timestamp_millis(&mut self) -> &mut Self {
+        self.default_format_timestamp(Some(TimestampPrecision::Millis))
+    }
+
+    /// Configures the timestamp to use microsecond precision.
+    pub fn default_format_timestamp_micros(&mut self) -> &mut Self {
+        self.default_format_timestamp(Some(TimestampPrecision::Micros))
+    }
+
+    /// Configures the timestamp to use nanosecond precision.
+    pub fn default_format_timestamp_nanos(&mut self) -> &mut Self {
+        self.default_format_timestamp(Some(TimestampPrecision::Nanos))
     }
 
     /// Adds a directive to the filter for a specific module.

--- a/tests/init-twice-retains-filter.rs
+++ b/tests/init-twice-retains-filter.rs
@@ -1,8 +1,8 @@
-extern crate log;
 extern crate env_logger;
+extern crate log;
 
-use std::process;
 use std::env;
+use std::process;
 use std::str;
 
 fn main() {
@@ -20,7 +20,7 @@ fn main() {
             .unwrap_err();
 
         assert_eq!(log::LevelFilter::Debug, log::max_level());
-        return
+        return;
     }
 
     let exe = env::current_exe().unwrap();
@@ -30,7 +30,7 @@ fn main() {
         .output()
         .unwrap_or_else(|e| panic!("Unable to start child process: {}", e));
     if out.status.success() {
-        return
+        return;
     }
 
     println!("test failed: {}", out.status);

--- a/tests/log-in-log.rs
+++ b/tests/log-in-log.rs
@@ -1,9 +1,10 @@
-#[macro_use] extern crate log;
+#[macro_use]
+extern crate log;
 extern crate env_logger;
 
-use std::process;
-use std::fmt;
 use std::env;
+use std::fmt;
+use std::process;
 use std::str;
 
 struct Foo;
@@ -28,7 +29,7 @@ fn main() {
         .output()
         .unwrap_or_else(|e| panic!("Unable to start child process: {}", e));
     if out.status.success() {
-        return
+        return;
     }
 
     println!("test failed: {}", out.status);

--- a/tests/regexp_filter.rs
+++ b/tests/regexp_filter.rs
@@ -1,8 +1,9 @@
-#[macro_use] extern crate log;
+#[macro_use]
+extern crate log;
 extern crate env_logger;
 
-use std::process;
 use std::env;
+use std::process;
 use std::str;
 
 fn main() {
@@ -25,7 +26,9 @@ fn run_child(rust_log: String) -> bool {
         .env("RUST_LOG", rust_log)
         .output()
         .unwrap_or_else(|e| panic!("Unable to start child process: {}", e));
-    str::from_utf8(out.stderr.as_ref()).unwrap().contains("XYZ Message")
+    str::from_utf8(out.stderr.as_ref())
+        .unwrap()
+        .contains("XYZ Message")
 }
 
 fn assert_message_printed(rust_log: &str) {
@@ -36,7 +39,10 @@ fn assert_message_printed(rust_log: &str) {
 
 fn assert_message_not_printed(rust_log: &str) {
     if run_child(rust_log.to_string()) {
-        panic!("RUST_LOG={} should not allow the test log message", rust_log)
+        panic!(
+            "RUST_LOG={} should not allow the test log message",
+            rust_log
+        )
     }
 }
 


### PR DESCRIPTION
Updates to the 2018 edition, removes deprecated items, and run `cargo fmt` to tidy things up a bit.