### PR TITLE
Prepare for 0.7.0 release

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "env_logger"
 edition = "2018"
-version = "0.6.2" # remember to update html_root_url
+version = "0.7.0" # remember to update html_root_url
 authors = ["The Rust Project Developers"]
 license = "MIT/Apache-2.0"
 readme = "README.md"

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ It must be added along with `log` to the project dependencies:
 ```toml
 [dependencies]
 log = "0.4.0"
-env_logger = "0.6.2"
+env_logger = "0.7.0"
 ```
 
 `env_logger` must be initialized as early as possible in the project. After it's initialized, you can use the `log` macros to do actual logging.
@@ -53,7 +53,7 @@ Tests can use the `env_logger` crate to see log messages generated during that t
 log = "0.4.0"
 
 [dev-dependencies]
-env_logger = "0.6.2"
+env_logger = "0.7.0"
 ```
 
 ```rust

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -237,7 +237,7 @@
 #![doc(
     html_logo_url = "https://www.rust-lang.org/logos/rust-logo-128x128-blk-v2.png",
     html_favicon_url = "https://www.rust-lang.org/static/images/favicon.ico",
-    html_root_url = "https://docs.rs/env_logger/0.6.2"
+    html_root_url = "https://docs.rs/env_logger/0.7.0"
 )]
 #![cfg_attr(test, deny(warnings))]
 // When compiled for the rustc compiler itself we want to make sure that this is


### PR DESCRIPTION
[Changes since the last release](https://github.com/sebasmagri/env_logger/compare/v0.6.2...master)

This is a breaking release that includes bumping our minimum supported Rust version to `1.31.0` for the 2018 Edition.

Includes:

- #134 
- #140
- #141 
- #142 