### PR TITLE
Change color of DEBUG and TRACE for improved readability

### DIFF
--- a/src/fmt/writer/termcolor/extern_impl.rs
+++ b/src/fmt/writer/termcolor/extern_impl.rs
@@ -52,7 +52,7 @@ impl Formatter {
         let mut level_style = self.style();
         match level {
             Level::Trace => level_style.set_color(Color::Black).set_intense(true),
-            Level::Debug => level_style.set_color(Color::White),
+            Level::Debug => level_style.set_color(Color::Blue),
             Level::Info => level_style.set_color(Color::Green),
             Level::Warn => level_style.set_color(Color::Yellow),
             Level::Error => level_style.set_color(Color::Red).set_bold(true),

--- a/src/fmt/writer/termcolor/extern_impl.rs
+++ b/src/fmt/writer/termcolor/extern_impl.rs
@@ -51,7 +51,7 @@ impl Formatter {
     pub fn default_level_style(&self, level: Level) -> Style {
         let mut level_style = self.style();
         match level {
-            Level::Trace => level_style.set_color(Color::Black).set_intense(true),
+            Level::Trace => level_style.set_color(Color::Cyan),
             Level::Debug => level_style.set_color(Color::Blue),
             Level::Info => level_style.set_color(Color::Green),
             Level::Warn => level_style.set_color(Color::Yellow),


### PR DESCRIPTION
This makes the log level much more readable when using a theme with a light background or a low contrast dark theme.

Fixes #138